### PR TITLE
Refactor: refactor base encodings for consistency, correctness, and deduplication

### DIFF
--- a/SimpleBaseLib/src/Alphabets/SbpAliasedBase32Alphabet.pas
+++ b/SimpleBaseLib/src/Alphabets/SbpAliasedBase32Alphabet.pas
@@ -9,6 +9,7 @@ uses
   SbpCharMap,
   SbpPaddingPosition,
   SbpCharUtilities,
+  SbpCodingAlphabet,
   SbpIAliasedBase32Alphabet,
   SbpBase32Alphabet;
 
@@ -53,7 +54,9 @@ procedure TAliasedBase32Alphabet.MapAlternate(ASource, ADestination: Char);
 var
   LResult: Int32;
 begin
-  LResult := ReverseLookupTable[Ord(ADestination)] - 1;
+  if not TCodingAlphabet.TryLookup(ReverseLookupTable, ADestination, LResult) then
+    raise EArgumentSimpleBaseLibException.CreateFmt(
+      'Character "%s" is not in the alphabet', [ADestination]);
   Map(ASource, LResult);
   Map(TCharUtilities.ToAsciiLower(ASource), LResult);
 end;

--- a/SimpleBaseLib/src/Alphabets/SbpBase16Alphabet.pas
+++ b/SimpleBaseLib/src/Alphabets/SbpBase16Alphabet.pas
@@ -5,18 +5,14 @@ unit SbpBase16Alphabet;
 interface
 
 uses
-  SysUtils,
   SbpICodingAlphabet,
   SbpIBase16Alphabet,
-  SbpCharUtilities,
   SbpCodingAlphabet;
 
 type
   TBase16Alphabet = class(TCodingAlphabet, IBase16Alphabet)
   strict private
     FCaseSensitive: Boolean;
-
-    procedure MapCounterparts;
   public
     class var FUpperCaseAlphabet: ICodingAlphabet;
     class var FLowerCaseAlphabet: ICodingAlphabet;
@@ -58,36 +54,8 @@ end;
 constructor TBase16Alphabet.Create(const AAlphabet: String;
   const ACaseSensitive: Boolean);
 begin
-  inherited Create(16, AAlphabet, False);
+  inherited Create(16, AAlphabet, not ACaseSensitive);
   FCaseSensitive := ACaseSensitive;
-
-  if not FCaseSensitive then
-  begin
-    MapCounterparts;
-  end;
-end;
-
-procedure TBase16Alphabet.MapCounterparts;
-var
-  LI, LAlphaLen: Int32;
-  LChar: Char;
-begin
-  LAlphaLen := System.Length(Value);
-  for LI := 0 to LAlphaLen - 1 do
-  begin
-    LChar := Value[LI + 1];
-    if TCharUtilities.IsLetter(LChar) then
-    begin
-      if TCharUtilities.IsAsciiUpper(LChar) then
-      begin
-        Map(TCharUtilities.ToAsciiLower(LChar), LI);
-      end
-      else
-      begin
-        Map(TCharUtilities.ToAsciiUpper(LChar), LI);
-      end;
-    end;
-  end;
 end;
 
 class function TBase16Alphabet.GetUpperCase: ICodingAlphabet;

--- a/SimpleBaseLib/src/Alphabets/SbpBase32Alphabet.pas
+++ b/SimpleBaseLib/src/Alphabets/SbpBase32Alphabet.pas
@@ -180,7 +180,7 @@ var
 begin
   if FCrockfordAlphabet = nil then
   begin
-    SetLength(LMap, 3);
+    System.SetLength(LMap, 3);
     LMap[0] := CMap[0];
     LMap[1] := CMap[1];
     LMap[2] := CMap[2];
@@ -203,7 +203,7 @@ var
 begin
   if FBase32HAlphabet = nil then
   begin
-    SetLength(LMap, 4);
+    System.SetLength(LMap, 4);
     LMap[0] := CMap[0];
     LMap[1] := CMap[1];
     LMap[2] := CMap[2];

--- a/SimpleBaseLib/src/Alphabets/SbpCodingAlphabet.pas
+++ b/SimpleBaseLib/src/Alphabets/SbpCodingAlphabet.pas
@@ -37,6 +37,9 @@ type
     function ToString: String; override;
     function GetHashCode: {$IFDEF DELPHI}Int32;{$ELSE}PtrInt;{$ENDIF DELPHI}override;
 
+    class function TryLookup(const ATable: TSimpleBaseLibByteArray;
+      AChar: Char; out AValue: Int32): Boolean; static; inline;
+
     property Value: String read GetValue;
     property Length: Int32 read GetLength;
     property ReverseLookupTable: TSimpleBaseLibByteArray read GetReverseLookupTable;
@@ -135,6 +138,19 @@ begin
  Assert(Ord(AChar) < MaxAlphabetChar, Format('Alphabet contains character above %d', [MaxAlphabetChar]));
 {$ENDIF DEBUG}
  FReverseLookupTable[Ord(AChar)] := Byte(AValue + 1);
+end;
+
+class function TCodingAlphabet.TryLookup(const ATable: TSimpleBaseLibByteArray;
+  AChar: Char; out AValue: Int32): Boolean;
+begin
+  if Ord(AChar) >= System.Length(ATable) then
+  begin
+    AValue := -1;
+    Result := False;
+    Exit;
+  end;
+  AValue := ATable[Ord(AChar)] - 1;
+  Result := AValue >= 0;
 end;
 
 end.

--- a/SimpleBaseLib/src/Bases/SbpBase16.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase16.pas
@@ -13,6 +13,7 @@ uses
   SbpIBaseStreamCoder,
   SbpINonAllocatingBaseCoder,
   SbpStreamUtilities,
+  SbpCodingAlphabet,
   SbpBase16Alphabet;
 
 type
@@ -40,6 +41,9 @@ type
 
     class procedure InternalEncode(const AInput: TSimpleBaseLibByteArray;
       const AOutput: TSimpleBaseLibCharArray; const AAlphabet: String); static;
+
+    function InternalDecode(const AInput: String;
+      const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
 
   public
     class constructor Create;
@@ -141,23 +145,24 @@ end;
 
 function TBase16.Decode(const AText: String): TSimpleBaseLibByteArray;
 var
-  LTextLen: Int32;
-  LSafeCount: Int32;
-  LBytesWritten: Int32;
+  LSafeCount, LBytesWritten: Int32;
 begin
-  LTextLen := System.Length(AText);
-  if LTextLen = 0 then
+  if System.Length(AText) = 0 then
   begin
     Result := nil;
     Exit;
   end;
 
   LSafeCount := GetSafeByteCountForDecoding(AText);
-  System.SetLength(Result, LSafeCount);
-
-  if not TryDecode(AText, Result, LBytesWritten) then
+  if LSafeCount = 0 then
   begin
-    raise EArgumentSimpleBaseLibException.Create('Invalid text');
+    raise EArgumentSimpleBaseLibException.Create('Invalid text length');
+  end;
+
+  System.SetLength(Result, LSafeCount);
+  if not InternalDecode(AText, Result, LBytesWritten) then
+  begin
+    raise EArgumentSimpleBaseLibException.Create('Invalid character in input');
   end;
 end;
 
@@ -193,20 +198,18 @@ function TBase16.TryDecode(const AText: String;
   const AOutput: TSimpleBaseLibByteArray;
   out ABytesWritten: Int32): Boolean;
 var
-  LTextLen, LI, LO, LByte1, LByte2, LOutputLen: Int32;
-  LChar1, LChar2: Char;
+  LTextLen, LOutputLen: Int32;
 begin
+  ABytesWritten := 0;
   LTextLen := System.Length(AText);
   if LTextLen = 0 then
   begin
-    ABytesWritten := 0;
     Result := True;
     Exit;
   end;
 
   if (LTextLen and 1) <> 0 then
   begin
-    ABytesWritten := 0;
     Result := False;
     Exit;
   end;
@@ -214,35 +217,11 @@ begin
   LOutputLen := LTextLen div 2;
   if System.Length(AOutput) < LOutputLen then
   begin
-    ABytesWritten := 0;
     Result := False;
     Exit;
   end;
 
-  LO := 0;
-  LI := 1;
-  while LI <= LTextLen do
-  begin
-    LChar1 := AText[LI];
-    LChar2 := AText[LI + 1];
-
-    LByte1 := FAlphabet.ReverseLookupTable[Ord(LChar1)] - 1;
-    LByte2 := FAlphabet.ReverseLookupTable[Ord(LChar2)] - 1;
-
-    if (LByte1 < 0) or (LByte2 < 0) then
-    begin
-      ABytesWritten := LO;
-      Result := False;
-      Exit;
-    end;
-
-    AOutput[LO] := Byte((LByte1 * 16) or LByte2);
-    Inc(LO);
-    Inc(LI, 2);
-  end;
-
-  ABytesWritten := LO;
-  Result := True;
+  Result := InternalDecode(AText, AOutput, ABytesWritten);
 end;
 
 function TBase16.Encode(const ABytes: TSimpleBaseLibByteArray): String;
@@ -260,9 +239,9 @@ begin
 
   LAlphabet := FAlphabet.Value;
   LSafeCount := GetSafeCharCountForEncoding(ABytes);
-  SetLength(LOutput, LSafeCount);
+  System.SetLength(LOutput, LSafeCount);
   InternalEncode(ABytes, LOutput, LAlphabet);
-  SetString(Result, PChar(@LOutput[0]), Length(LOutput));
+  SetString(Result, PChar(@LOutput[0]), System.Length(LOutput));
 end;
 
 function TBase16.TryEncode(const ABytes: TSimpleBaseLibByteArray;
@@ -271,20 +250,18 @@ var
   LLen, LOutputLen: Int32;
   LAlphabet: String;
 begin
+  ACharsWritten := 0;
   LLen := System.Length(ABytes);
-  LOutputLen := LLen * 2;
-
-  if System.Length(AOutput) < LOutputLen then
+  if LLen = 0 then
   begin
-    ACharsWritten := 0;
-    Result := False;
+    Result := True;
     Exit;
   end;
 
-  if LOutputLen = 0 then
+  LOutputLen := LLen * 2;
+  if System.Length(AOutput) < LOutputLen then
   begin
-    ACharsWritten := 0;
-    Result := True;
+    Result := False;
     Exit;
   end;
 
@@ -292,6 +269,39 @@ begin
   InternalEncode(ABytes, AOutput, LAlphabet);
 
   ACharsWritten := LOutputLen;
+  Result := True;
+end;
+
+function TBase16.InternalDecode(const AInput: String;
+  const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
+var
+  LTextLen, LI, LO, LByte1, LByte2: Int32;
+  LChar1, LChar2: Char;
+  LTable: TSimpleBaseLibByteArray;
+begin
+  LTable := FAlphabet.ReverseLookupTable;
+  LTextLen := System.Length(AInput);
+  LO := 0;
+  LI := 1;
+  while LI <= LTextLen do
+  begin
+    LChar1 := AInput[LI];
+    LChar2 := AInput[LI + 1];
+
+    if (not TCodingAlphabet.TryLookup(LTable, LChar1, LByte1)) or
+      (not TCodingAlphabet.TryLookup(LTable, LChar2, LByte2)) then
+    begin
+      ABytesWritten := LO;
+      Result := False;
+      Exit;
+    end;
+
+    AOutput[LO] := Byte((LByte1 * 16) or LByte2);
+    Inc(LO);
+    Inc(LI, 2);
+  end;
+
+  ABytesWritten := LO;
   Result := True;
 end;
 

--- a/SimpleBaseLib/src/Bases/SbpBase2.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase2.pas
@@ -82,9 +82,15 @@ function TBase2.Decode(const AText: String): TSimpleBaseLibByteArray;
 var
   LOutputLen: Int32;
 begin
+  if System.Length(AText) = 0 then
+  begin
+    Result := nil;
+    Exit;
+  end;
+
   if (System.Length(AText) mod 8) <> 0 then
   begin
-    raise EArgumentSimpleBaseLibException.Create('Input length must be multiply of 8');
+    raise EArgumentSimpleBaseLibException.Create('Input length must be a multiple of 8');
   end;
 
   LOutputLen := System.Length(AText) div 8;
@@ -170,6 +176,12 @@ var
   LTargetLen: Int32;
 begin
   ACharsWritten := 0;
+  if System.Length(ABytes) = 0 then
+  begin
+    Result := True;
+    Exit;
+  end;
+
   LTargetLen := System.Length(ABytes) * 8;
   if System.Length(AOutput) < LTargetLen then
   begin

--- a/SimpleBaseLib/src/Bases/SbpBase32.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase32.pas
@@ -16,6 +16,8 @@ uses
   SbpPaddingPosition,
   SbpBase32Alphabet,
   SbpStreamUtilities,
+  SbpCodingAlphabet,
+  SbpBitOperations,
   SbpPlatformUtilities,
   SbpBinaryPrimitives;
 
@@ -69,7 +71,7 @@ type
     function GetPaddingCharCount(const AText: String): Int32;
     function InternalEncode(const AInput: TSimpleBaseLibByteArray;
       const AOutput: TSimpleBaseLibCharArray; APadding: Boolean; out ACharsWritten: Int32): Boolean;
-    function InternalDecode(const AInput: String;
+    function InternalDecode(const AInput: String; AInputLen: Int32;
       const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): TDecodeResult;
     function GetAlphabet: IBase32Alphabet;
   public
@@ -129,7 +131,7 @@ begin
   FGeohash := nil;
   FBech32 := nil;
   FFileCoin := nil;
-  SetLength(FZeroBuffer, 1);
+  System.SetLength(FZeroBuffer, 1);
   FZeroBuffer[0] := 0;
 end;
 
@@ -236,6 +238,11 @@ end;
 function TBase32.GetSafeCharCountForEncoding(
   const ABytes: TSimpleBaseLibByteArray): Int32;
 begin
+  if System.Length(ABytes) = 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
   Result := (((System.Length(ABytes) - 1) div BitsPerChar) + 1) * BitsPerByte;
 end;
 
@@ -264,11 +271,11 @@ begin
   end;
 
   LOutputLen := GetSafeCharCountForEncoding(ABytes);
-  SetLength(LOutput, LOutputLen);
+  System.SetLength(LOutput, LOutputLen);
   if not InternalEncode(ABytes, LOutput, APadding, LCharsWritten) then
   begin
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'Internal error: couldn''t calculate proper output buffer size for input');
+      'Internal error: insufficient output buffer size');
   end;
   SetString(Result, PChar(@LOutput[0]), LCharsWritten);
 end;
@@ -288,24 +295,19 @@ begin
     Exit;
   end;
 
-  SetLength(LOutput, LOutputLen);
-  LDecodeResult := InternalDecode(System.Copy(AText, 1, LTextLen), LOutput, LBytesWritten);
+  System.SetLength(LOutput, LOutputLen);
+  LDecodeResult := InternalDecode(AText, LTextLen, LOutput, LBytesWritten);
   case LDecodeResult of
     TDecodeResult.InvalidInput:
       raise EArgumentSimpleBaseLibException.Create('Invalid character in input');
     TDecodeResult.OutputOverflow:
-      raise EInvalidOperationSimpleBaseLibException.Create('Output buffer is too small');
+      raise EInvalidOperationSimpleBaseLibException.Create(
+        'Internal error: insufficient output buffer size');
     TDecodeResult.Success:
-      begin
-        if LBytesWritten <> LOutputLen then
-        begin
-          raise EInvalidOperationSimpleBaseLibException.Create(
-            'Actual written bytes are different');
-        end;
-        Result := LOutput;
-      end;
+      Result := System.Copy(LOutput, 0, LBytesWritten);
   else
-    raise EInvalidOperationSimpleBaseLibException.Create('Unhandled decode result');
+    raise EInvalidOperationSimpleBaseLibException.Create(
+      'Unexpected decode result');
   end;
 end;
 
@@ -324,6 +326,7 @@ const
 var
   LBuffer, LSpan: TSimpleBaseLibByteArray;
   LI: Int32;
+  LTmp: Byte;
 begin
   if ANumber = 0 then
   begin
@@ -331,7 +334,7 @@ begin
     Exit;
   end;
 
-  SetLength(LBuffer, NumBytes);
+  System.SetLength(LBuffer, NumBytes);
   TBinaryPrimitives.WriteUInt64LittleEndian(LBuffer, 0, ANumber);
 
   if FIsBigEndian then
@@ -344,9 +347,9 @@ begin
     LSpan := System.Copy(LBuffer, LI, NumBytes - LI);
     for LI := 0 to (System.Length(LSpan) div 2) - 1 do
     begin
-      LBuffer[0] := LSpan[LI];
+      LTmp := LSpan[LI];
       LSpan[LI] := LSpan[System.Length(LSpan) - 1 - LI];
-      LSpan[System.Length(LSpan) - 1 - LI] := LBuffer[0];
+      LSpan[System.Length(LSpan) - 1 - LI] := LTmp;
     end;
     Result := Encode(LSpan);
     Exit;
@@ -364,15 +367,21 @@ function TBase32.DecodeUInt64(const AText: String): UInt64;
 var
   LBuffer, LNewSpan: TSimpleBaseLibByteArray;
   LI: Int32;
+  LTmp: Byte;
 begin
   LBuffer := Decode(AText);
+  if System.Length(LBuffer) = 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
   if System.Length(LBuffer) > 8 then
   begin
     raise EInvalidOperationSimpleBaseLibException.Create(
       'Decoded text is too long to fit in a buffer');
   end;
 
-  SetLength(LNewSpan, 8);
+  System.SetLength(LNewSpan, 8);
   for LI := 0 to 7 do
   begin
     LNewSpan[LI] := 0;
@@ -383,11 +392,9 @@ begin
   begin
     for LI := 0 to 3 do
     begin
-      LBuffer := nil;
-      SetLength(LBuffer, 1);
-      LBuffer[0] := LNewSpan[LI];
+      LTmp := LNewSpan[LI];
       LNewSpan[LI] := LNewSpan[7 - LI];
-      LNewSpan[7 - LI] := LBuffer[0];
+      LNewSpan[7 - LI] := LTmp;
     end;
   end;
 
@@ -400,7 +407,7 @@ var
   LBytesWritten, LI: Int32;
   LTmp: Byte;
 begin
-  SetLength(LOutput, 8);
+  System.SetLength(LOutput, 8);
   for LI := 0 to 7 do
   begin
     LOutput[LI] := 0;
@@ -455,6 +462,12 @@ begin
     Result := True;
     Exit;
   end;
+  if System.Length(AOutput) < GetSafeCharCountForEncoding(ABytes) then
+  begin
+    ACharsWritten := 0;
+    Result := False;
+    Exit;
+  end;
   Result := InternalEncode(ABytes, AOutput, APadding, ACharsWritten);
 end;
 
@@ -471,14 +484,14 @@ begin
     Exit;
   end;
 
-  if System.Length(AOutput) = 0 then
+  if System.Length(AOutput) < GetSafeByteCountForDecoding(AText) then
   begin
     ABytesWritten := 0;
     Result := False;
     Exit;
   end;
 
-  Result := InternalDecode(System.Copy(AText, 1, LInputLen), AOutput, ABytesWritten) =
+  Result := InternalDecode(AText, LInputLen, AOutput, ABytesWritten) =
     TDecodeResult.Success;
 end;
 
@@ -489,6 +502,13 @@ var
   LBitsLeft, LOutputPad, LO, LValue, LI, LNextBits: Int32;
   LPaddingChar: Char;
 begin
+  if System.Length(AInput) = 0 then
+  begin
+    ACharsWritten := 0;
+    Result := True;
+    Exit;
+  end;
+
   LTable := FAlphabet.Value;
   LBitsLeft := BitsPerByte;
   LO := 0;
@@ -576,7 +596,7 @@ begin
   end;
 end;
 
-function TBase32.InternalDecode(const AInput: String;
+function TBase32.InternalDecode(const AInput: String; AInputLen: Int32;
   const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): TDecodeResult;
 var
   LTable: TSimpleBaseLibByteArray;
@@ -589,11 +609,10 @@ begin
   ABytesWritten := 0;
   LO := 0;
 
-  for LI := 1 to System.Length(AInput) do
+  for LI := 1 to AInputLen do
   begin
     LC := AInput[LI];
-    LB := LTable[Ord(LC)] - 1;
-    if LB < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LC, LB) then
     begin
       ABytesWritten := LO;
       Result := TDecodeResult.InvalidInput;
@@ -608,7 +627,7 @@ begin
     end;
 
     LShiftBits := BitsPerChar - LBitsLeft;
-    LOutputPad := LOutputPad or (LB shr LShiftBits);
+    LOutputPad := LOutputPad or TBitOperations.Asr32(LB, LShiftBits);
     if LO >= System.Length(AOutput) then
     begin
       Result := TDecodeResult.OutputOverflow;

--- a/SimpleBaseLib/src/Bases/SbpBase45.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase45.pas
@@ -14,6 +14,8 @@ uses
   SbpIBaseStreamCoder,
   SbpIBase45,
   SbpBase45Alphabet,
+  SbpCodingAlphabet,
+  SbpBitOperations,
   SbpStreamUtilities;
 
 type
@@ -50,6 +52,8 @@ type
     class function GetDecodingBufferSize(ALen: Int32): Int32; static; inline;
     class function GetEncodingBufferSize(ALen: Int32): Int32; static; inline;
 
+    function InternalEncode(const AInput: TSimpleBaseLibByteArray;
+      const AOutput: TSimpleBaseLibCharArray; out ACharsWritten: Int32): Boolean;
     function InternalDecode(const AInput: String;
       const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): TDecodeOutcome;
   public
@@ -145,6 +149,62 @@ begin
   Result := GetEncodingBufferSize(System.Length(ABytes));
 end;
 
+function TBase45.InternalEncode(const AInput: TSimpleBaseLibByteArray;
+  const AOutput: TSimpleBaseLibCharArray; out ACharsWritten: Int32): Boolean;
+var
+  LWholeBlocks, LRemainder, LWholeLen, LOutputLength: Int32;
+  LI: Int32;
+  LA, LB, LValue, LQuotient, LC, LD, LE: UInt16;
+  LAlphabet: String;
+begin
+  LWholeBlocks := System.Length(AInput) div 2;
+  LRemainder := System.Length(AInput) mod 2;
+  LWholeLen := LWholeBlocks * 2;
+  ACharsWritten := 0;
+
+  LOutputLength := GetEncodingBufferSize(System.Length(AInput));
+  if System.Length(AOutput) < LOutputLength then
+  begin
+    Result := False;
+    Exit;
+  end;
+
+  LAlphabet := FAlphabet.Value;
+  LI := 0;
+  while LI < LWholeLen do
+  begin
+    LA := AInput[LI];
+    Inc(LI);
+    LB := AInput[LI];
+    Inc(LI);
+    LValue := UInt16((LA shl 8) or LB);
+
+    LC := LValue mod 45;
+    LQuotient := LValue div 45;
+    LD := LQuotient mod 45;
+    LE := LQuotient div 45;
+
+    AOutput[ACharsWritten] := LAlphabet[LC + 1];
+    Inc(ACharsWritten);
+    AOutput[ACharsWritten] := LAlphabet[LD + 1];
+    Inc(ACharsWritten);
+    AOutput[ACharsWritten] := LAlphabet[LE + 1];
+    Inc(ACharsWritten);
+  end;
+
+  if LRemainder = 1 then
+  begin
+    LD := AInput[LI] div 45;
+    LC := AInput[LI] mod 45;
+    AOutput[ACharsWritten] := LAlphabet[LC + 1];
+    Inc(ACharsWritten);
+    AOutput[ACharsWritten] := LAlphabet[LD + 1];
+    Inc(ACharsWritten);
+  end;
+
+  Result := True;
+end;
+
 function TBase45.InternalDecode(const AInput: String;
   const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): TDecodeOutcome;
 var
@@ -181,8 +241,7 @@ begin
   begin
     LChr := AInput[LI];
     Inc(LI);
-    LC := LTable[Ord(LChr)] - 1;
-    if LC < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LChr, LC) then
     begin
       Result.Status := TDecodeResult.InvalidCharacter;
       Result.InvalidChar := LChr;
@@ -191,8 +250,7 @@ begin
 
     LChr := AInput[LI];
     Inc(LI);
-    LD := LTable[Ord(LChr)] - 1;
-    if LD < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LChr, LD) then
     begin
       Result.Status := TDecodeResult.InvalidCharacter;
       Result.InvalidChar := LChr;
@@ -201,8 +259,7 @@ begin
 
     LChr := AInput[LI];
     Inc(LI);
-    LE := LTable[Ord(LChr)] - 1;
-    if LE < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LChr, LE) then
     begin
       Result.Status := TDecodeResult.InvalidCharacter;
       Result.InvalidChar := LChr;
@@ -217,7 +274,7 @@ begin
       Exit;
     end;
 
-    AOutput[ABytesWritten] := Byte((LValue shr 8) and $FF);
+    AOutput[ABytesWritten] := Byte(TBitOperations.Asr32(LValue, 8) and $FF);
     Inc(ABytesWritten);
     AOutput[ABytesWritten] := Byte(LValue and $FF);
     Inc(ABytesWritten);
@@ -227,8 +284,7 @@ begin
   begin
     LChr := AInput[LI];
     Inc(LI);
-    LC := LTable[Ord(LChr)] - 1;
-    if LC < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LChr, LC) then
     begin
       Result.Status := TDecodeResult.InvalidCharacter;
       Result.InvalidChar := LChr;
@@ -236,8 +292,7 @@ begin
     end;
 
     LChr := AInput[LI];
-    LD := LTable[Ord(LChr)] - 1;
-    if LD < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LChr, LD) then
     begin
       Result.Status := TDecodeResult.InvalidCharacter;
       Result.InvalidChar := LChr;
@@ -266,22 +321,21 @@ var
   LOutput: TSimpleBaseLibByteArray;
   LOutcome: TDecodeOutcome;
 begin
+  if System.Length(AText) = 0 then
+  begin
+    Result := nil;
+    Exit;
+  end;
+
   LOutputLen := GetDecodingBufferSize(System.Length(AText));
   System.SetLength(LOutput, LOutputLen);
   LOutcome := InternalDecode(AText, LOutput, LBytesWritten);
   case LOutcome.Status of
     TDecodeResult.Success:
-      begin
-        if LBytesWritten <> System.Length(LOutput) then
-        begin
-          raise EInvalidOperationSimpleBaseLibException.Create(
-            'Inconsistent buffer size returned -- probably a bug');
-        end;
-        Result := LOutput;
-      end;
+      Result := System.Copy(LOutput, 0, LBytesWritten);
     TDecodeResult.InvalidOutputLength:
       raise EInvalidOperationSimpleBaseLibException.Create(
-        'Failed to allocate sufficient buffer -- likely a bug');
+        'Internal error: insufficient output buffer size');
     TDecodeResult.InvalidCharacter:
       raise EArgumentSimpleBaseLibException.CreateFmt('Invalid character: %s',
         [LOutcome.InvalidChar]);
@@ -292,7 +346,7 @@ begin
       raise EArgumentSimpleBaseLibException.Create(
         'Input buffer is at incorrect size');
   else
-    raise ENotSupportedSimpleBaseLibException.Create('Unsupported decode result');
+    raise EInvalidOperationSimpleBaseLibException.Create('Unexpected decode result');
   end;
 end;
 
@@ -309,10 +363,10 @@ begin
   end;
 
   System.SetLength(LOutput, LOutputLen);
-  if not TryEncode(ABytes, LOutput, LCharsWritten) then
+  if not InternalEncode(ABytes, LOutput, LCharsWritten) then
   begin
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'Failed to allocate large enough buffer -- likely a bug');
+      'Internal error: insufficient output buffer size');
   end;
   SetString(Result, PChar(@LOutput[0]), LCharsWritten);
 end;
@@ -322,64 +376,38 @@ function TBase45.TryDecode(const AText: String;
 var
   LOutcome: TDecodeOutcome;
 begin
+  if System.Length(AText) = 0 then
+  begin
+    ABytesWritten := 0;
+    Result := True;
+    Exit;
+  end;
+  if System.Length(AOutput) < GetSafeByteCountForDecoding(AText) then
+  begin
+    ABytesWritten := 0;
+    Result := False;
+    Exit;
+  end;
   LOutcome := InternalDecode(AText, AOutput, ABytesWritten);
   Result := LOutcome.Status = TDecodeResult.Success;
 end;
 
 function TBase45.TryEncode(const ABytes: TSimpleBaseLibByteArray;
   const AOutput: TSimpleBaseLibCharArray; out ACharsWritten: Int32): Boolean;
-var
-  LWholeBlocks, LRemainder, LWholeLen, LOutputLength: Int32;
-  LI: Int32;
-  LA, LB, LValue, LQuotient, LC, LD, LE: UInt16;
-  LAlphabet: String;
 begin
-  LWholeBlocks := System.Length(ABytes) div 2;
-  LRemainder := System.Length(ABytes) mod 2;
-  LWholeLen := LWholeBlocks * 2;
-  ACharsWritten := 0;
-
-  LOutputLength := GetEncodingBufferSize(System.Length(ABytes));
-  if System.Length(AOutput) < LOutputLength then
+  if System.Length(ABytes) = 0 then
   begin
+    ACharsWritten := 0;
+    Result := True;
+    Exit;
+  end;
+  if System.Length(AOutput) < GetSafeCharCountForEncoding(ABytes) then
+  begin
+    ACharsWritten := 0;
     Result := False;
     Exit;
   end;
-
-  LAlphabet := FAlphabet.Value;
-  LI := 0;
-  while LI < LWholeLen do
-  begin
-    LA := ABytes[LI];
-    Inc(LI);
-    LB := ABytes[LI];
-    Inc(LI);
-    LValue := UInt16((LA shl 8) or LB);
-
-    LC := LValue mod 45;
-    LQuotient := LValue div 45;
-    LD := LQuotient mod 45;
-    LE := LQuotient div 45;
-
-    AOutput[ACharsWritten] := LAlphabet[LC + 1];
-    Inc(ACharsWritten);
-    AOutput[ACharsWritten] := LAlphabet[LD + 1];
-    Inc(ACharsWritten);
-    AOutput[ACharsWritten] := LAlphabet[LE + 1];
-    Inc(ACharsWritten);
-  end;
-
-  if LRemainder = 1 then
-  begin
-    LD := ABytes[LI] div 45;
-    LC := ABytes[LI] mod 45;
-    AOutput[ACharsWritten] := LAlphabet[LC + 1];
-    Inc(ACharsWritten);
-    AOutput[ACharsWritten] := LAlphabet[LD + 1];
-    Inc(ACharsWritten);
-  end;
-
-  Result := True;
+  Result := InternalEncode(ABytes, AOutput, ACharsWritten);
 end;
 
 procedure TBase45.Decode(const AInput: TStringBuilder; const AOutput: TStream);

--- a/SimpleBaseLib/src/Bases/SbpBase64.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase64.pas
@@ -8,11 +8,14 @@ uses
   Classes,
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibConstants,
   SbpIBase64,
   SbpIBase64Alphabet,
   SbpINonAllocatingBaseCoder,
   SbpIBaseStreamCoder,
   SbpBase64Alphabet,
+  SbpCodingAlphabet,
+  SbpBitOperations,
   SbpStreamUtilities;
 
 type
@@ -20,7 +23,18 @@ type
     IBaseStreamCoder)
   strict private
   type
-    TBase64Kind = (StandardPadded, StandardNoPad, UrlNoPad, UrlPadded);
+    TDecodeResult = (
+      Success,
+      InsufficientOutputBuffer,
+      InvalidCharacter,
+      InvalidLength,
+      InvalidPadding
+    );
+
+    TDecodeOutcome = record
+      Status: TDecodeResult;
+      InvalidChar: Char;
+    end;
 
   const
     EncodeBlockSize = Int32(3);
@@ -30,7 +44,6 @@ type
   var
     FAlphabet: IBase64Alphabet;
     FPadding: Boolean;
-    FKind: TBase64Kind;
 
     class var FDefault: IBase64;
     class var FDefaultNoPad: IBase64;
@@ -49,23 +62,29 @@ type
     function EncodeBuffer(ABytes: TSimpleBaseLibByteArray;
       ALastBlock: Boolean): String;
 
-    class function EncodeInternal(const ABytes: TSimpleBaseLibByteArray;
+    class function InternalEncode(const ABytes: TSimpleBaseLibByteArray;
+      const AOutput: TSimpleBaseLibCharArray;
+      const AAlphabetValue: String; APadding: Boolean;
+      out ACharsWritten: Int32): Boolean; static;
+    class function InternalDecode(const AText: String;
+      const AOutput: TSimpleBaseLibByteArray;
+      const AReverseLookup: TSimpleBaseLibByteArray;
+      AAllowNoPadding: Boolean;
+      out ABytesWritten: Int32): TDecodeOutcome; static;
+
+    class function GetSafeByteCountForDecodingInternal(ATextLength: Int32): Int32; static; inline;
+    class function GetSafeCharCountForEncodingInternal(ABytesLength: Int32;
+      APadding: Boolean): Int32; static; inline;
+
+    class function AllocatingEncode(const ABytes: TSimpleBaseLibByteArray;
       const AAlphabetValue: String; APadding: Boolean): String; static;
-    class function DecodeInternal(const AText: String;
+    class function AllocatingDecode(const AText: String;
       const AReverseLookup: TSimpleBaseLibByteArray;
       AAllowNoPadding: Boolean): TSimpleBaseLibByteArray; static;
-    class function DecodeValue(AChar: Char;
-      const AReverseLookup: TSimpleBaseLibByteArray): Byte; static;
-    class function NormalizeTextForDecoding(const AText: String;
-      AAllowNoPadding: Boolean): String; static;
-
-    function DecodeBasedOnKind(const AText: String): TSimpleBaseLibByteArray;
-    function EncodeBasedOnKind(const ABytes: TSimpleBaseLibByteArray): String;
   public
     class constructor Create;
 
-    constructor Create(const AAlphabet: IBase64Alphabet; APadding: Boolean;
-      AKind: TBase64Kind);
+    constructor Create(const AAlphabet: IBase64Alphabet; APadding: Boolean);
 
     class function DecodeUrl(const AText: String): TSimpleBaseLibByteArray; static;
     class function TryDecodeUrl(const AText: String;
@@ -114,20 +133,18 @@ begin
   FUrlPadded := nil;
 end;
 
-constructor TBase64.Create(const AAlphabet: IBase64Alphabet; APadding: Boolean;
-  AKind: TBase64Kind);
+constructor TBase64.Create(const AAlphabet: IBase64Alphabet; APadding: Boolean);
 begin
   inherited Create;
   FAlphabet := AAlphabet;
   FPadding := APadding;
-  FKind := AKind;
 end;
 
 class function TBase64.GetDefault: IBase64;
 begin
   if FDefault = nil then
   begin
-    FDefault := TBase64.Create(TBase64Alphabet.Default, True, TBase64Kind.StandardPadded);
+    FDefault := TBase64.Create(TBase64Alphabet.Default, True);
   end;
   Result := FDefault;
 end;
@@ -136,7 +153,7 @@ class function TBase64.GetDefaultNoPad: IBase64;
 begin
   if FDefaultNoPad = nil then
   begin
-    FDefaultNoPad := TBase64.Create(TBase64Alphabet.Default, False, TBase64Kind.StandardNoPad);
+    FDefaultNoPad := TBase64.Create(TBase64Alphabet.Default, False);
   end;
   Result := FDefaultNoPad;
 end;
@@ -145,7 +162,7 @@ class function TBase64.GetUrl: IBase64;
 begin
   if FUrl = nil then
   begin
-    FUrl := TBase64.Create(TBase64Alphabet.Url, False, TBase64Kind.UrlNoPad);
+    FUrl := TBase64.Create(TBase64Alphabet.Url, False);
   end;
   Result := FUrl;
 end;
@@ -154,7 +171,7 @@ class function TBase64.GetUrlPadded: IBase64;
 begin
   if FUrlPadded = nil then
   begin
-    FUrlPadded := TBase64.Create(TBase64Alphabet.Url, True, TBase64Kind.UrlPadded);
+    FUrlPadded := TBase64.Create(TBase64Alphabet.Url, True);
   end;
   Result := FUrlPadded;
 end;
@@ -169,17 +186,20 @@ begin
   Result := FPadding;
 end;
 
-class function TBase64.EncodeInternal(const ABytes: TSimpleBaseLibByteArray;
-  const AAlphabetValue: String; APadding: Boolean): String;
+class function TBase64.InternalEncode(const ABytes: TSimpleBaseLibByteArray;
+  const AOutput: TSimpleBaseLibCharArray;
+  const AAlphabetValue: String; APadding: Boolean;
+  out ACharsWritten: Int32): Boolean;
 var
   LLen, LWholeBlocks, LRemainder, LOutLen: Int32;
   LI, LOutIndex: Int32;
   LB0, LB1, LB2: Byte;
 begin
+  ACharsWritten := 0;
   LLen := System.Length(ABytes);
   if LLen = 0 then
   begin
-    Result := '';
+    Result := True;
     Exit;
   end;
 
@@ -199,9 +219,14 @@ begin
     end;
   end;
 
-  SetLength(Result, LOutLen);
+  if System.Length(AOutput) < LOutLen then
+  begin
+    Result := False;
+    Exit;
+  end;
+
   LI := 0;
-  LOutIndex := 1;
+  LOutIndex := 0;
 
   while LI + 2 < LLen do
   begin
@@ -209,12 +234,12 @@ begin
     LB1 := ABytes[LI + 1];
     LB2 := ABytes[LI + 2];
 
-    Result[LOutIndex] := AAlphabetValue[(LB0 shr 2) + 1];
-    Result[LOutIndex + 1] := AAlphabetValue[((Int32(LB0 and $03) shl 4) or
+    AOutput[LOutIndex] := AAlphabetValue[(LB0 shr 2) + 1];
+    AOutput[LOutIndex + 1] := AAlphabetValue[((Int32(LB0 and $03) shl 4) or
       Int32(LB1 shr 4)) + 1];
-    Result[LOutIndex + 2] := AAlphabetValue[((Int32(LB1 and $0F) shl 2) or
+    AOutput[LOutIndex + 2] := AAlphabetValue[((Int32(LB1 and $0F) shl 2) or
       Int32(LB2 shr 6)) + 1];
-    Result[LOutIndex + 3] := AAlphabetValue[(LB2 and $3F) + 1];
+    AOutput[LOutIndex + 3] := AAlphabetValue[(LB2 and $3F) + 1];
 
     Inc(LI, 3);
     Inc(LOutIndex, 4);
@@ -223,391 +248,402 @@ begin
   if LRemainder = 1 then
   begin
     LB0 := ABytes[LI];
-    Result[LOutIndex] := AAlphabetValue[(LB0 shr 2) + 1];
-    Result[LOutIndex + 1] := AAlphabetValue[((LB0 and $03) shl 4) + 1];
+    AOutput[LOutIndex] := AAlphabetValue[(LB0 shr 2) + 1];
+    AOutput[LOutIndex + 1] := AAlphabetValue[((LB0 and $03) shl 4) + 1];
 
     if APadding then
     begin
-      Result[LOutIndex + 2] := PaddingChar;
-      Result[LOutIndex + 3] := PaddingChar;
+      AOutput[LOutIndex + 2] := PaddingChar;
+      AOutput[LOutIndex + 3] := PaddingChar;
     end;
   end;
   if LRemainder = 2 then
   begin
     LB0 := ABytes[LI];
     LB1 := ABytes[LI + 1];
-    Result[LOutIndex] := AAlphabetValue[(LB0 shr 2) + 1];
-    Result[LOutIndex + 1] := AAlphabetValue[((Int32(LB0 and $03) shl 4) or
+    AOutput[LOutIndex] := AAlphabetValue[(LB0 shr 2) + 1];
+    AOutput[LOutIndex + 1] := AAlphabetValue[((Int32(LB0 and $03) shl 4) or
       Int32(LB1 shr 4)) + 1];
-    Result[LOutIndex + 2] := AAlphabetValue[((LB1 and $0F) shl 2) + 1];
+    AOutput[LOutIndex + 2] := AAlphabetValue[((LB1 and $0F) shl 2) + 1];
 
     if APadding then
     begin
-      Result[LOutIndex + 3] := PaddingChar;
+      AOutput[LOutIndex + 3] := PaddingChar;
     end;
   end;
+
+  ACharsWritten := LOutLen;
+  Result := True;
 end;
 
-class function TBase64.DecodeUrl(const AText: String): TSimpleBaseLibByteArray;
-begin
-  Result := DecodeInternal(AText, TBase64Alphabet.Url.ReverseLookupTable, True);
-end;
-
-class function TBase64.TryDecodeUrl(const AText: String;
-  const ABytes: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
+class function TBase64.InternalDecode(const AText: String;
+  const AOutput: TSimpleBaseLibByteArray;
+  const AReverseLookup: TSimpleBaseLibByteArray;
+  AAllowNoPadding: Boolean;
+  out ABytesWritten: Int32): TDecodeOutcome;
 var
-  LDecoded: TSimpleBaseLibByteArray;
+  LTextLen, LPadCount, LDataLen, LRemainder: Int32;
+  LFullBlocks, LOutLen, LOutPos, LI: Int32;
+  LV1, LV2, LV3, LV4: Int32;
 begin
   ABytesWritten := 0;
-  try
-    LDecoded := DecodeUrl(AText);
-    if System.Length(ABytes) < System.Length(LDecoded) then
+  LTextLen := System.Length(AText);
+  if LTextLen = 0 then
+  begin
+    Result.Status := TDecodeResult.Success;
+    Result.InvalidChar := TSimpleBaseLibConstants.NullChar;
+    Exit;
+  end;
+
+  LPadCount := 0;
+  while (LPadCount < LTextLen) and
+    (AText[LTextLen - LPadCount] = PaddingChar) do
+    Inc(LPadCount);
+
+  if LPadCount > 2 then
+  begin
+    Result.Status := TDecodeResult.InvalidPadding;
+    Result.InvalidChar := PaddingChar;
+    Exit;
+  end;
+
+  LDataLen := LTextLen - LPadCount;
+
+  if LPadCount > 0 then
+  begin
+    if (LTextLen mod 4) <> 0 then
     begin
-      Result := False;
+      Result.Status := TDecodeResult.InvalidLength;
+      Result.InvalidChar := TSimpleBaseLibConstants.NullChar;
       Exit;
     end;
-    if System.Length(LDecoded) > 0 then
+  end
+  else if not AAllowNoPadding then
+  begin
+    if (LTextLen mod 4) <> 0 then
     begin
-      Move(LDecoded[0], ABytes[0], System.Length(LDecoded));
+      Result.Status := TDecodeResult.InvalidLength;
+      Result.InvalidChar := TSimpleBaseLibConstants.NullChar;
+      Exit;
     end;
-    ABytesWritten := System.Length(LDecoded);
-    Result := True;
-  except
-    Result := False;
   end;
-end;
 
-function TBase64.DecodeBasedOnKind(const AText: String): TSimpleBaseLibByteArray;
-begin
-  case FKind of
-    TBase64Kind.StandardPadded:
-      Result := DecodeInternal(AText, FAlphabet.ReverseLookupTable, False);
-    TBase64Kind.StandardNoPad:
-      Result := DecodeInternal(AText, FAlphabet.ReverseLookupTable, True);
-    TBase64Kind.UrlNoPad:
-      Result := DecodeInternal(AText, FAlphabet.ReverseLookupTable, True);
-    TBase64Kind.UrlPadded:
-      Result := DecodeInternal(AText, FAlphabet.ReverseLookupTable, False);
-  else
-    raise EInvalidOperationSimpleBaseLibException.Create('Unsupported Base64 mode');
-  end;
-end;
-
-function TBase64.EncodeBasedOnKind(const ABytes: TSimpleBaseLibByteArray): String;
-begin
-  case FKind of
-    TBase64Kind.StandardPadded:
-      Result := EncodeInternal(ABytes, FAlphabet.Value, True);
-    TBase64Kind.StandardNoPad:
-      Result := EncodeInternal(ABytes, FAlphabet.Value, False);
-    TBase64Kind.UrlNoPad:
-      Result := EncodeInternal(ABytes, FAlphabet.Value, False);
-    TBase64Kind.UrlPadded:
-      Result := EncodeInternal(ABytes, FAlphabet.Value, True);
-  else
-    raise EInvalidOperationSimpleBaseLibException.Create('Unsupported Base64 mode');
-  end;
-end;
-
-class function TBase64.DecodeValue(AChar: Char;
-  const AReverseLookup: TSimpleBaseLibByteArray): Byte;
-var
-  LOrd: Int32;
-begin
-  LOrd := Ord(AChar);
-  if (LOrd < 0) or (LOrd >= System.Length(AReverseLookup)) then
+  LRemainder := LDataLen mod 4;
+  if LRemainder = 1 then
   begin
-    raise EArgumentSimpleBaseLibException.CreateFmt(
-      'Invalid Base64 character "%s"', [AChar]);
+    Result.Status := TDecodeResult.InvalidLength;
+    Result.InvalidChar := TSimpleBaseLibConstants.NullChar;
+    Exit;
   end;
 
-  Result := AReverseLookup[LOrd];
-  if Result = 0 then
+  for LI := 1 to LDataLen do
   begin
-    raise EArgumentSimpleBaseLibException.CreateFmt(
-      'Invalid Base64 character "%s"', [AChar]);
+    if AText[LI] = PaddingChar then
+    begin
+      Result.Status := TDecodeResult.InvalidPadding;
+      Result.InvalidChar := PaddingChar;
+      Exit;
+    end;
   end;
-  Dec(Result);
+
+  LFullBlocks := LDataLen div 4;
+  LOutLen := LFullBlocks * 3;
+  case LRemainder of
+    2: Inc(LOutLen, 1);
+    3: Inc(LOutLen, 2);
+  end;
+
+  if System.Length(AOutput) < LOutLen then
+  begin
+    Result.Status := TDecodeResult.InsufficientOutputBuffer;
+    Result.InvalidChar := TSimpleBaseLibConstants.NullChar;
+    Exit;
+  end;
+
+  LOutPos := 0;
+  LI := 1;
+
+  while LFullBlocks > 0 do
+  begin
+    if not TCodingAlphabet.TryLookup(AReverseLookup, AText[LI], LV1) then
+    begin
+      Result.Status := TDecodeResult.InvalidCharacter;
+      Result.InvalidChar := AText[LI];
+      Exit;
+    end;
+
+    if not TCodingAlphabet.TryLookup(AReverseLookup, AText[LI + 1], LV2) then
+    begin
+      Result.Status := TDecodeResult.InvalidCharacter;
+      Result.InvalidChar := AText[LI + 1];
+      Exit;
+    end;
+
+    if not TCodingAlphabet.TryLookup(AReverseLookup, AText[LI + 2], LV3) then
+    begin
+      Result.Status := TDecodeResult.InvalidCharacter;
+      Result.InvalidChar := AText[LI + 2];
+      Exit;
+    end;
+
+    if not TCodingAlphabet.TryLookup(AReverseLookup, AText[LI + 3], LV4) then
+    begin
+      Result.Status := TDecodeResult.InvalidCharacter;
+      Result.InvalidChar := AText[LI + 3];
+      Exit;
+    end;
+
+    AOutput[LOutPos] := Byte((LV1 shl 2) or TBitOperations.Asr32(LV2, 4));
+    AOutput[LOutPos + 1] := Byte(((LV2 and $0F) shl 4) or TBitOperations.Asr32(LV3, 2));
+    AOutput[LOutPos + 2] := Byte(((LV3 and $03) shl 6) or LV4);
+
+    Inc(LOutPos, 3);
+    Inc(LI, 4);
+    Dec(LFullBlocks);
+  end;
+
+  if LRemainder >= 2 then
+  begin
+    if not TCodingAlphabet.TryLookup(AReverseLookup, AText[LI], LV1) then
+    begin
+      Result.Status := TDecodeResult.InvalidCharacter;
+      Result.InvalidChar := AText[LI];
+      Exit;
+    end;
+    if not TCodingAlphabet.TryLookup(AReverseLookup, AText[LI + 1], LV2) then
+    begin
+      Result.Status := TDecodeResult.InvalidCharacter;
+      Result.InvalidChar := AText[LI + 1];
+      Exit;
+    end;
+
+    AOutput[LOutPos] := Byte((LV1 shl 2) or TBitOperations.Asr32(LV2, 4));
+    Inc(LOutPos);
+
+    if LRemainder = 3 then
+    begin
+      if not TCodingAlphabet.TryLookup(AReverseLookup, AText[LI + 2], LV3) then
+      begin
+        Result.Status := TDecodeResult.InvalidCharacter;
+        Result.InvalidChar := AText[LI + 2];
+        Exit;
+      end;
+
+      AOutput[LOutPos] := Byte(((LV2 and $0F) shl 4) or TBitOperations.Asr32(LV3, 2));
+    end;
+  end;
+
+  ABytesWritten := LOutLen;
+  Result.Status := TDecodeResult.Success;
+  Result.InvalidChar := TSimpleBaseLibConstants.NullChar;
 end;
 
-class function TBase64.NormalizeTextForDecoding(const AText: String;
-  AAllowNoPadding: Boolean): String;
-var
-  LLen, LMod: Int32;
+class function TBase64.GetSafeByteCountForDecodingInternal(ATextLength: Int32): Int32;
 begin
-  LLen := System.Length(AText);
+  Result := ((ATextLength + 3) div 4) * 3;
+end;
+
+class function TBase64.GetSafeCharCountForEncodingInternal(ABytesLength: Int32;
+  APadding: Boolean): Int32;
+begin
+  if ABytesLength = 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
+  if APadding then
+    Result := ((ABytesLength + 2) div 3) * 4
+  else
+    Result := (ABytesLength * 4 + 2) div 3;
+end;
+
+class function TBase64.AllocatingEncode(const ABytes: TSimpleBaseLibByteArray;
+  const AAlphabetValue: String; APadding: Boolean): String;
+var
+  LLen, LOutputLen, LCharsWritten: Int32;
+  LOutput: TSimpleBaseLibCharArray;
+begin
+  LLen := System.Length(ABytes);
   if LLen = 0 then
   begin
     Result := '';
     Exit;
   end;
 
-  LMod := LLen mod 4;
-  if not AAllowNoPadding then
+  LOutputLen := GetSafeCharCountForEncodingInternal(LLen, True);
+  System.SetLength(LOutput, LOutputLen);
+  if not InternalEncode(ABytes, LOutput, AAlphabetValue, APadding, LCharsWritten) then
   begin
-    if LMod <> 0 then
-    begin
-      raise EArgumentSimpleBaseLibException.Create('Invalid Base64 string length');
-    end;
-    Result := AText;
+    raise EInvalidOperationSimpleBaseLibException.Create(
+      'Internal error: insufficient output buffer size');
+  end;
+  SetString(Result, PChar(@LOutput[0]), LCharsWritten);
+end;
+
+class function TBase64.AllocatingDecode(const AText: String;
+  const AReverseLookup: TSimpleBaseLibByteArray;
+  AAllowNoPadding: Boolean): TSimpleBaseLibByteArray;
+var
+  LDecodeBufferLen, LBytesWritten: Int32;
+  LDecodeBuffer: TSimpleBaseLibByteArray;
+  LOutcome: TDecodeOutcome;
+begin
+  if System.Length(AText) = 0 then
+  begin
+    Result := nil;
     Exit;
   end;
 
-  case LMod of
-    0:
-      Result := AText;
-    2:
-      begin
-        Result := AText + StringOfChar(PaddingChar, 2);
-      end;
-    3:
-      begin
-        Result := AText + PaddingChar;
-      end;
+  LDecodeBufferLen := GetSafeByteCountForDecodingInternal(System.Length(AText));
+  System.SetLength(LDecodeBuffer, LDecodeBufferLen);
+  LOutcome := InternalDecode(AText, LDecodeBuffer, AReverseLookup,
+    AAllowNoPadding, LBytesWritten);
+  case LOutcome.Status of
+    TDecodeResult.Success:
+      Result := System.Copy(LDecodeBuffer, 0, LBytesWritten);
+    TDecodeResult.InvalidCharacter:
+      raise EArgumentSimpleBaseLibException.CreateFmt(
+        'Invalid Base64 character "%s"', [LOutcome.InvalidChar]);
+    TDecodeResult.InvalidLength:
+      raise EArgumentSimpleBaseLibException.Create('Invalid Base64 string length');
+    TDecodeResult.InvalidPadding:
+      raise EArgumentSimpleBaseLibException.Create('Invalid Base64 padding placement');
+    TDecodeResult.InsufficientOutputBuffer:
+      raise EInvalidOperationSimpleBaseLibException.Create(
+        'Internal error: insufficient output buffer size');
   else
-    raise EArgumentSimpleBaseLibException.Create('Invalid Base64 string length');
+    raise EInvalidOperationSimpleBaseLibException.Create(
+      'Unexpected decode result');
   end;
+end;
+
+class function TBase64.DecodeUrl(const AText: String): TSimpleBaseLibByteArray;
+begin
+  Result := AllocatingDecode(AText, TBase64Alphabet.Url.ReverseLookupTable, True);
+end;
+
+class function TBase64.TryDecodeUrl(const AText: String;
+  const ABytes: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
+var
+  LOutcome: TDecodeOutcome;
+begin
+  ABytesWritten := 0;
+  if System.Length(AText) = 0 then
+  begin
+    Result := True;
+    Exit;
+  end;
+  if System.Length(ABytes) < GetSafeByteCountForDecodingInternal(System.Length(AText)) then
+  begin
+    Result := False;
+    Exit;
+  end;
+  LOutcome := InternalDecode(AText, ABytes,
+    TBase64Alphabet.Url.ReverseLookupTable, True, ABytesWritten);
+  Result := LOutcome.Status = TDecodeResult.Success;
 end;
 
 class function TBase64.EncodeUrl(const ABytes: TSimpleBaseLibByteArray): String;
 begin
-  Result := EncodeInternal(ABytes, TBase64Alphabet.Url.Value, False);
+  Result := AllocatingEncode(ABytes, TBase64Alphabet.Url.Value, False);
 end;
 
 class function TBase64.EncodeUrlPadded(const ABytes: TSimpleBaseLibByteArray): String;
 begin
-  Result := EncodeInternal(ABytes, TBase64Alphabet.Url.Value, True);
+  Result := AllocatingEncode(ABytes, TBase64Alphabet.Url.Value, True);
 end;
 
 class function TBase64.EncodeWithoutPadding(
   const ABytes: TSimpleBaseLibByteArray): String;
 begin
-  Result := EncodeInternal(ABytes, TBase64Alphabet.Default.Value, False);
+  Result := AllocatingEncode(ABytes, TBase64Alphabet.Default.Value, False);
 end;
 
 class function TBase64.DecodeWithoutPadding(
   const AText: String): TSimpleBaseLibByteArray;
 begin
-  Result := DecodeInternal(AText, TBase64Alphabet.Default.ReverseLookupTable, True);
+  Result := AllocatingDecode(AText, TBase64Alphabet.Default.ReverseLookupTable, True);
 end;
 
 class function TBase64.TryDecodeWithoutPadding(const AText: String;
   const ABytes: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
 var
-  LDecoded: TSimpleBaseLibByteArray;
+  LOutcome: TDecodeOutcome;
 begin
   ABytesWritten := 0;
-  try
-    LDecoded := DecodeWithoutPadding(AText);
-    if System.Length(ABytes) < System.Length(LDecoded) then
-    begin
-      Result := False;
-      Exit;
-    end;
-    if System.Length(LDecoded) > 0 then
-    begin
-      Move(LDecoded[0], ABytes[0], System.Length(LDecoded));
-    end;
-    ABytesWritten := System.Length(LDecoded);
-    Result := True;
-  except
-    Result := False;
-  end;
-end;
-
-class function TBase64.DecodeInternal(const AText: String;
-  const AReverseLookup: TSimpleBaseLibByteArray;
-  AAllowNoPadding: Boolean): TSimpleBaseLibByteArray;
-var
-  LNormalized: String;
-  LLen, LPadCount, LI, LBlockCount, LOutPos, LOutLen: Int32;
-  LC1, LC2, LC3, LC4: Char;
-  LV1, LV2, LV3, LV4: Byte;
-begin
-  LNormalized := NormalizeTextForDecoding(AText, AAllowNoPadding);
-  LLen := System.Length(LNormalized);
-  if LLen = 0 then
+  if System.Length(AText) = 0 then
   begin
-    SetLength(Result, 0);
+    Result := True;
     Exit;
   end;
-
-  if LLen mod 4 <> 0 then
+  if System.Length(ABytes) < GetSafeByteCountForDecodingInternal(System.Length(AText)) then
   begin
-    raise EArgumentSimpleBaseLibException.Create('Invalid Base64 string length');
+    Result := False;
+    Exit;
   end;
-
-  LPadCount := 0;
-  if LNormalized[LLen] = PaddingChar then
-  begin
-    LPadCount := 1;
-    if (LLen > 1) and (LNormalized[LLen - 1] = PaddingChar) then
-    begin
-      LPadCount := 2;
-    end;
-  end;
-
-  for LI := 1 to LLen - LPadCount do
-  begin
-    if LNormalized[LI] = PaddingChar then
-    begin
-      raise EArgumentSimpleBaseLibException.Create('Invalid Base64 padding placement');
-    end;
-  end;
-
-  LBlockCount := LLen div 4;
-  LOutLen := (LBlockCount * 3) - LPadCount;
-  SetLength(Result, LOutLen);
-  LOutPos := 0;
-
-  for LI := 0 to LBlockCount - 1 do
-  begin
-    LC1 := LNormalized[(LI * 4) + 1];
-    LC2 := LNormalized[(LI * 4) + 2];
-    LC3 := LNormalized[(LI * 4) + 3];
-    LC4 := LNormalized[(LI * 4) + 4];
-
-    LV1 := DecodeValue(LC1, AReverseLookup);
-    LV2 := DecodeValue(LC2, AReverseLookup);
-
-    if LC3 = PaddingChar then
-    begin
-      if (LC4 <> PaddingChar) or (LI <> LBlockCount - 1) then
-      begin
-        raise EArgumentSimpleBaseLibException.Create('Invalid Base64 padding placement');
-      end;
-      Result[LOutPos] := Byte((LV1 shl 2) or (LV2 shr 4));
-      Break;
-    end;
-
-    LV3 := DecodeValue(LC3, AReverseLookup);
-    Result[LOutPos] := Byte((LV1 shl 2) or (LV2 shr 4));
-    Inc(LOutPos);
-    Result[LOutPos] := Byte((Int32(LV2 and $0F) shl 4) or Int32(LV3 shr 2));
-
-    if LC4 = PaddingChar then
-    begin
-      if LI <> LBlockCount - 1 then
-      begin
-        raise EArgumentSimpleBaseLibException.Create('Invalid Base64 padding placement');
-      end;
-      Break;
-    end;
-
-    LV4 := DecodeValue(LC4, AReverseLookup);
-    Inc(LOutPos);
-    Result[LOutPos] := Byte(((LV3 and $03) shl 6) or LV4);
-    Inc(LOutPos);
-  end;
+  LOutcome := InternalDecode(AText, ABytes,
+    TBase64Alphabet.Default.ReverseLookupTable, True, ABytesWritten);
+  Result := LOutcome.Status = TDecodeResult.Success;
 end;
 
 function TBase64.Decode(const AText: String): TSimpleBaseLibByteArray;
 begin
-  Result := DecodeBasedOnKind(AText);
+  Result := AllocatingDecode(AText, FAlphabet.ReverseLookupTable, not FPadding);
 end;
 
 function TBase64.Encode(const ABytes: TSimpleBaseLibByteArray): String;
 begin
-  Result := EncodeBasedOnKind(ABytes);
+  Result := AllocatingEncode(ABytes, FAlphabet.Value, FPadding);
 end;
 
 function TBase64.GetSafeByteCountForDecoding(const AText: String): Int32;
-var
-  LLen: Int32;
 begin
-  LLen := System.Length(AText);
-
-  if FPadding then
-  begin
-    Result := ((LLen + 3) div 4) * 3;
-  end
-  else
-  begin
-    case (LLen mod 4) of
-      0:
-        Result := (LLen div 4) * 3;
-      2:
-        Result := ((LLen + 2) div 4) * 3;
-      3:
-        Result := ((LLen + 1) div 4) * 3;
-    else
-      Result := ((LLen + 3) div 4) * 3;
-    end;
-  end;
+  Result := GetSafeByteCountForDecodingInternal(System.Length(AText));
 end;
 
 function TBase64.GetSafeCharCountForEncoding(
   const ABytes: TSimpleBaseLibByteArray): Int32;
-var
-  LLen, LRem: Int32;
 begin
-  LLen := System.Length(ABytes);
-  if LLen = 0 then
-  begin
-    Result := 0;
-    Exit;
-  end;
-
-  if FPadding then
-  begin
-    Result := ((LLen + 2) div 3) * 4;
-    Exit;
-  end;
-
-  Result := (LLen div 3) * 4;
-  LRem := LLen mod 3;
-  case LRem of
-    1:
-      Inc(Result, 2);
-    2:
-      Inc(Result, 3);
-  end;
+  Result := GetSafeCharCountForEncodingInternal(System.Length(ABytes), FPadding);
 end;
 
 function TBase64.TryDecode(const AText: String;
   const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
 var
-  LDecoded: TSimpleBaseLibByteArray;
+  LOutcome: TDecodeOutcome;
 begin
   ABytesWritten := 0;
-  try
-    LDecoded := Decode(AText);
-    if System.Length(AOutput) < System.Length(LDecoded) then
-    begin
-      Result := False;
-      Exit;
-    end;
-    if System.Length(LDecoded) > 0 then
-    begin
-      Move(LDecoded[0], AOutput[0], System.Length(LDecoded));
-    end;
-    ABytesWritten := System.Length(LDecoded);
+  if System.Length(AText) = 0 then
+  begin
     Result := True;
-  except
-    Result := False;
+    Exit;
   end;
-end;
-
-function TBase64.TryEncode(const ABytes: TSimpleBaseLibByteArray;
-  const AOutput: TSimpleBaseLibCharArray; out ACharsWritten: Int32): Boolean;
-var
-  LEncoded: String;
-  LI: Int32;
-begin
-  ACharsWritten := 0;
-  LEncoded := Encode(ABytes);
-  if System.Length(AOutput) < System.Length(LEncoded) then
+  if System.Length(AOutput) < GetSafeByteCountForDecodingInternal(System.Length(AText)) then
   begin
     Result := False;
     Exit;
   end;
+  LOutcome := InternalDecode(AText, AOutput,
+    FAlphabet.ReverseLookupTable, not FPadding, ABytesWritten);
+  Result := LOutcome.Status = TDecodeResult.Success;
+end;
 
-  for LI := 1 to System.Length(LEncoded) do
+function TBase64.TryEncode(const ABytes: TSimpleBaseLibByteArray;
+  const AOutput: TSimpleBaseLibCharArray; out ACharsWritten: Int32): Boolean;
+begin
+  ACharsWritten := 0;
+  if System.Length(ABytes) = 0 then
   begin
-    AOutput[LI - 1] := LEncoded[LI];
+    Result := True;
+    Exit;
   end;
-  ACharsWritten := System.Length(LEncoded);
-  Result := True;
+  if System.Length(AOutput) < GetSafeCharCountForEncoding(ABytes) then
+  begin
+    Result := False;
+    Exit;
+  end;
+  Result := InternalEncode(ABytes, AOutput, FAlphabet.Value,
+    FPadding, ACharsWritten);
 end;
 
 function TBase64.DecodeBuffer(AText: String): TSimpleBaseLibByteArray;

--- a/SimpleBaseLib/src/Bases/SbpBase8.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase8.pas
@@ -97,6 +97,12 @@ var
   LOutputLen, LBytesWritten: Int32;
   LDecodeResult: TDecodeResult;
 begin
+  if System.Length(AText) = 0 then
+  begin
+    Result := nil;
+    Exit;
+  end;
+
   LOutputLen := GetSafeByteCountForDecodingInternal(System.Length(AText));
   System.SetLength(Result, LOutputLen);
   LDecodeResult := InternalDecode(AText, Result, LBytesWritten);
@@ -172,15 +178,15 @@ function TBase8.TryDecode(const AText: String;
   const AOutput: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
 begin
   ABytesWritten := 0;
-  if System.Length(AOutput) < GetSafeByteCountForDecodingInternal(System.Length(AText)) then
-  begin
-    Result := False;
-    Exit;
-  end;
-
   if System.Length(AText) = 0 then
   begin
     Result := True;
+    Exit;
+  end;
+
+  if System.Length(AOutput) < GetSafeByteCountForDecodingInternal(System.Length(AText)) then
+  begin
+    Result := False;
     Exit;
   end;
 
@@ -190,9 +196,15 @@ end;
 function TBase8.TryEncode(const ABytes: TSimpleBaseLibByteArray;
   const AOutput: TSimpleBaseLibCharArray; out ACharsWritten: Int32): Boolean;
 begin
+  ACharsWritten := 0;
+  if System.Length(ABytes) = 0 then
+  begin
+    Result := True;
+    Exit;
+  end;
+
   if System.Length(AOutput) < GetSafeCharCountForEncodingInternal(System.Length(ABytes)) then
   begin
-    ACharsWritten := 0;
     Result := False;
     Exit;
   end;

--- a/SimpleBaseLib/src/Bases/SbpBase85.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase85.pas
@@ -14,6 +14,8 @@ uses
   SbpINonAllocatingBaseCoder,
   SbpIBaseStreamCoder,
   SbpBase85Alphabet,
+  SbpCodingAlphabet,
+  SbpBitOperations,
   SbpStreamUtilities;
 
 type
@@ -161,6 +163,11 @@ end;
 class function TBase85.GetSafeByteCountForDecodingInternal(ATextLength: Int32;
   AUsingShortcuts: Boolean): Int32;
 begin
+  if ATextLength = 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
   if AUsingShortcuts then
   begin
     Result := ATextLength * EncodeBlockSize;
@@ -208,11 +215,11 @@ begin
   end;
 
   LOutputLen := GetSafeCharCountForEncoding(ABytes);
-  SetLength(LOutput, LOutputLen);
+  System.SetLength(LOutput, LOutputLen);
   if not InternalEncode(ABytes, LOutput, LCharsWritten) then
   begin
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'Insufficient output buffer size while encoding Base85');
+      'Internal error: insufficient output buffer size');
   end;
   SetString(Result, PChar(@LOutput[0]), LCharsWritten);
 end;
@@ -224,6 +231,12 @@ begin
   begin
     ACharsWritten := 0;
     Result := True;
+    Exit;
+  end;
+  if System.Length(AOutput) < GetSafeCharCountForEncoding(ABytes) then
+  begin
+    ACharsWritten := 0;
+    Result := False;
     Exit;
   end;
   Result := InternalEncode(ABytes, AOutput, ACharsWritten);
@@ -242,7 +255,7 @@ begin
   end;
 
   LDecodeBufferLen := GetSafeByteCountForDecodingInternal(System.Length(AText), FAlphabet.HasShortcut);
-  SetLength(LDecodeBuffer, LDecodeBufferLen);
+  System.SetLength(LDecodeBuffer, LDecodeBufferLen);
   LOutcome := InternalDecode(AText, LDecodeBuffer, LBytesWritten);
   case LOutcome.Status of
     TDecodeResult.Success:
@@ -254,10 +267,10 @@ begin
         'Invalid location for a shortcut character: %s', [LOutcome.InvalidChar]);
     TDecodeResult.InsufficientOutputBuffer:
       raise EInvalidOperationSimpleBaseLibException.Create(
-        'Internal error: pre-allocated insufficient output buffer size');
+        'Internal error: insufficient output buffer size');
   else
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'This should be never hit - probably a bug');
+      'Unexpected decode result');
   end;
 end;
 
@@ -266,6 +279,18 @@ function TBase85.TryDecode(const AText: String;
 var
   LOutcome: TDecodeOutcome;
 begin
+  if System.Length(AText) = 0 then
+  begin
+    ABytesWritten := 0;
+    Result := True;
+    Exit;
+  end;
+  if System.Length(AOutput) < GetSafeByteCountForDecoding(AText) then
+  begin
+    ABytesWritten := 0;
+    Result := False;
+    Exit;
+  end;
   LOutcome := InternalDecode(AText, AOutput, ABytesWritten);
   Result := LOutcome.Status = TDecodeResult.Success;
 end;
@@ -351,7 +376,7 @@ begin
     begin
       Break;
     end;
-    AOutput[AOutputOffset + LO] := Byte((AValue shr (LI * 8)) and $FF);
+    AOutput[AOutputOffset + LO] := Byte(TBitOperations.Asr64(AValue, LI * 8) and $FF);
     Inc(LO);
     Dec(ANumBytesToWrite);
   end;
@@ -371,7 +396,6 @@ begin
     Exit;
   end;
 
-  ABlockIndex := 0;
   Result := WriteDecodedValue(AOutput, AOutputOffset, AValue, EncodeBlockSize, ABytesWritten);
 end;
 
@@ -491,8 +515,7 @@ begin
       Continue;
     end;
 
-    LX := LTable[Ord(LC)] - 1;
-    if LX < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LC, LX) then
     begin
       Result.Status := TDecodeResult.InvalidCharacter;
       Result.InvalidChar := LC;

--- a/SimpleBaseLib/src/Bases/SbpMoneroBase58.pas
+++ b/SimpleBaseLib/src/Bases/SbpMoneroBase58.pas
@@ -9,10 +9,12 @@ uses
   SbpSimpleBaseLibTypes,
   SbpSimpleBaseLibConstants,
   SbpICodingAlphabet,
+  SbpCodingAlphabet,
   SbpINonAllocatingBaseCoder,
   SbpIMoneroBase58,
   SbpBase58Alphabet,
-  SbpBinaryPrimitives;
+  SbpBinaryPrimitives,
+  SbpBits;
 
 type
   TMoneroBase58 = class(TInterfacedObject, IMoneroBase58, INonAllocatingBaseCoder)
@@ -44,8 +46,6 @@ type
     class function GetSafeCharCountForEncodingInternal(ALength: Int32): Int32; static; inline;
     class function GetSafeByteCountForDecodingInternal(ALength: Int32): Int32; static; inline;
     class function GetDecodedBlockSizeFromEncodedLength(AEncodedLen: Int32): Int32; static;
-    class function ReadPartialBigEndianUInt64(const AInput: TSimpleBaseLibByteArray;
-      AOffset, ACount: Int32): UInt64; static;
 
     class procedure EncodeBlock(const AInput: TSimpleBaseLibByteArray; AInputOffset, AInputLen: Int32;
       const AOutput: TSimpleBaseLibCharArray; AOutputOffset: Int32;
@@ -124,11 +124,21 @@ end;
 
 class function TMoneroBase58.GetSafeCharCountForEncodingInternal(ALength: Int32): Int32;
 begin
+  if ALength = 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
   Result := ((ALength div BlockSize) + 1) * MaxEncodedBlockSize;
 end;
 
 class function TMoneroBase58.GetSafeByteCountForDecodingInternal(ALength: Int32): Int32;
 begin
+  if ALength = 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
   Result := (ALength * BlockSize div MaxEncodedBlockSize) + 1;
 end;
 
@@ -159,18 +169,6 @@ begin
   Result := -1;
 end;
 
-class function TMoneroBase58.ReadPartialBigEndianUInt64(
-  const AInput: TSimpleBaseLibByteArray; AOffset, ACount: Int32): UInt64;
-var
-  LI: Int32;
-begin
-  Result := 0;
-  for LI := 0 to ACount - 1 do
-  begin
-    Result := (Result shl 8) or AInput[AOffset + LI];
-  end;
-end;
-
 class procedure TMoneroBase58.EncodeBlock(const AInput: TSimpleBaseLibByteArray;
   AInputOffset, AInputLen: Int32; const AOutput: TSimpleBaseLibCharArray;
   AOutputOffset: Int32; const AAlphabet: String; AZeroChar: Char);
@@ -178,7 +176,7 @@ var
   LPad, LRemainder: UInt64;
   LLastPos, LI: Int32;
 begin
-  LPad := ReadPartialBigEndianUInt64(AInput, AInputOffset, AInputLen);
+  LPad := TBits.PartialBigEndianBytesToUInt64(AInput, AInputOffset, AInputLen);
   LLastPos := EncodedBlockSizes[AInputLen];
 
   for LI := LLastPos - 1 downto 0 do
@@ -207,8 +205,7 @@ begin
   for LI := 0 to AInputLen - 1 do
   begin
     LC := AInput[AInputOffset + LI];
-    LValue := AReverseLookupTable[Ord(LC)] - 1;
-    if LValue < 0 then
+    if not TCodingAlphabet.TryLookup(AReverseLookupTable, LC, LValue) then
     begin
       Result.Status := TDecodeResult.InvalidCharacter;
       Result.InvalidChar := LC;
@@ -360,7 +357,7 @@ begin
   if not InternalEncode(ABytes, LOutput, LCharsWritten) then
   begin
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'Output buffer with insufficient size generated');
+      'Internal error: insufficient output buffer size');
   end;
   SetString(Result, PChar(@LOutput[0]), LCharsWritten);
 end;
@@ -389,16 +386,28 @@ begin
         [LOutcome.InvalidChar]);
     TDecodeResult.InsufficientOutputBuffer:
       raise EInvalidOperationSimpleBaseLibException.Create(
-        'Output buffer with insufficient size generated - likely a bug');
+        'Internal error: insufficient output buffer size');
   else
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'This should never be hit - likely a bug');
+      'Unexpected decode result');
   end;
 end;
 
 function TMoneroBase58.TryEncode(const ABytes: TSimpleBaseLibByteArray;
   const AOutput: TSimpleBaseLibCharArray; out ACharsWritten: Int32): Boolean;
 begin
+  if System.Length(ABytes) = 0 then
+  begin
+    ACharsWritten := 0;
+    Result := True;
+    Exit;
+  end;
+  if System.Length(AOutput) < GetSafeCharCountForEncoding(ABytes) then
+  begin
+    ACharsWritten := 0;
+    Result := False;
+    Exit;
+  end;
   Result := InternalEncode(ABytes, AOutput, ACharsWritten);
 end;
 
@@ -413,7 +422,12 @@ begin
     Result := True;
     Exit;
   end;
-
+  if System.Length(AOutput) < GetSafeByteCountForDecoding(AText) then
+  begin
+    ABytesWritten := 0;
+    Result := False;
+    Exit;
+  end;
   LOutcome := InternalDecode(AText, AOutput, ABytesWritten);
   Result := LOutcome.Status = TDecodeResult.Success;
 end;

--- a/SimpleBaseLib/src/Bases/SbpMultibase.pas
+++ b/SimpleBaseLib/src/Bases/SbpMultibase.pas
@@ -20,9 +20,6 @@ uses
 
 type
   TMultibase = class sealed(TObject)
-  strict private
-    class function TryDecodeBase64Pad(const AText: String;
-      const ABytes: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean; static;
   public
     class function Decode(const AText: String): TSimpleBaseLibByteArray; static;
     class function TryDecode(const AText: String;
@@ -79,10 +76,10 @@ begin
       Result := TBase58.Bitcoin.Decode(LRest);
     TMultibaseEncoding.Base58Flickr:
       Result := TBase58.Flickr.Decode(LRest);
-    TMultibaseEncoding.Base64Pad:
-      Result := TBase64.Default.Decode(LRest);
     TMultibaseEncoding.Base64:
       Result := TBase64.DefaultNoPad.Decode(LRest);
+    TMultibaseEncoding.Base64Pad:
+      Result := TBase64.Default.Decode(LRest);
     TMultibaseEncoding.Base64Url:
       Result := TBase64.Url.Decode(LRest);
     TMultibaseEncoding.Base64UrlPad:
@@ -91,12 +88,6 @@ begin
     raise EInvalidOperationSimpleBaseLibException.CreateFmt(
       'Unsupported multibase prefix: %s', [LC]);
   end;
-end;
-
-class function TMultibase.TryDecodeBase64Pad(const AText: String;
-  const ABytes: TSimpleBaseLibByteArray; out ABytesWritten: Int32): Boolean;
-begin
-  Result := TBase64.Default.TryDecode(AText, ABytes, ABytesWritten);
 end;
 
 class function TMultibase.TryDecode(const AText: String;
@@ -151,7 +142,7 @@ begin
     TMultibaseEncoding.Base64:
       Result := TBase64.DefaultNoPad.TryDecode(LRest, ABytes, ABytesWritten);
     TMultibaseEncoding.Base64Pad:
-      Result := TryDecodeBase64Pad(LRest, ABytes, ABytesWritten);
+      Result := TBase64.Default.TryDecode(LRest, ABytes, ABytesWritten);
     TMultibaseEncoding.Base64Url:
       Result := TBase64.Url.TryDecode(LRest, ABytes, ABytesWritten);
     TMultibaseEncoding.Base64UrlPad:

--- a/SimpleBaseLib/src/Coders/SbpDividingCoder.pas
+++ b/SimpleBaseLib/src/Coders/SbpDividingCoder.pas
@@ -11,6 +11,7 @@ uses
   SbpSimpleBaseLibConstants,
   SbpArrayUtilities,
   SbpICodingAlphabet,
+  SbpCodingAlphabet,
   SbpIBaseCoder,
   SbpIDividingCoder,
   SbpINonAllocatingBaseCoder,
@@ -242,8 +243,7 @@ begin
   for LI := AZeroPrefixLen + 1 to System.Length(AInput) do
   begin
     LCh := AInput[LI];
-    LCarry := LTable[Ord(LCh)] - 1;
-    if LCarry < 0 then
+    if not TCodingAlphabet.TryLookup(LTable, LCh, LCarry) then
     begin
       ARangeWritten.Start := 0;
       ARangeWritten.Finish := 0;
@@ -266,6 +266,14 @@ begin
 
   if AZeroPrefixLen > 0 then
   begin
+    if LMin < AZeroPrefixLen then
+    begin
+      ARangeWritten.Start := 0;
+      ARangeWritten.Finish := 0;
+      Result.Status := TDecodeResult.InsufficientOutputBuffer;
+      Result.InvalidChar := TSimpleBaseLibConstants.NullChar;
+      Exit;
+    end;
     for LI := (LMin - AZeroPrefixLen) to LMin - 1 do
     begin
       AOutput[LI] := 0;
@@ -302,7 +310,7 @@ begin
   else
   begin
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'Output buffer with insufficient size generated');
+      'Internal error: insufficient output buffer size');
   end;
 end;
 
@@ -333,7 +341,7 @@ begin
         [LOutcome.InvalidChar]);
     TDecodeResult.InsufficientOutputBuffer:
       raise EInvalidOperationSimpleBaseLibException.Create(
-        'Output buffer was too small while decoding');
+        'Internal error: insufficient output buffer size');
     TDecodeResult.Success:
       begin
         LRangeLen := LRangeWritten.Finish - LRangeWritten.Start;
@@ -341,7 +349,7 @@ begin
       end;
   else
     raise EInvalidOperationSimpleBaseLibException.Create(
-      'This should be never hit - probably a bug');
+      'Unexpected decode result');
   end;
 end;
 
@@ -352,10 +360,22 @@ function TDividingCoder.TryEncode(
 var
   LOutput: TSimpleBaseLibCharArray;
 begin
+  if System.Length(ABytes) = 0 then
+  begin
+    ACharsWritten := 0;
+    Result := True;
+    Exit;
+  end;
+  if System.Length(AOutput) < GetSafeCharCountForEncoding(ABytes) then
+  begin
+    ACharsWritten := 0;
+    Result := False;
+    Exit;
+  end;
   LOutput := AOutput;
   if System.Length(LOutput) > 0 then
   begin
-    TArrayUtilities.Fill<Char>(LOutput, 0, System.Length(LOutput), #0);
+    TArrayUtilities.Fill<Char>(LOutput, 0, System.Length(LOutput), TSimpleBaseLibConstants.NullChar);
   end;
   Result := InternalEncode(ABytes, LOutput,
     TBits.CountPrefixingZeroes(ABytes), ACharsWritten);
@@ -378,6 +398,12 @@ begin
     Exit;
   end;
 
+  if System.Length(AOutput) < GetSafeByteCountForDecoding(AText) then
+  begin
+    ABytesWritten := 0;
+    Result := False;
+    Exit;
+  end;
   LZeroPrefixLen := CountPrefixChars(AText, FZeroChar);
   LOutput := AOutput;
   if System.Length(LOutput) > 0 then

--- a/SimpleBaseLib/src/Misc/SbpBinaryPrimitives.pas
+++ b/SimpleBaseLib/src/Misc/SbpBinaryPrimitives.pas
@@ -84,7 +84,7 @@ implementation
 class procedure TBinaryPrimitives.CheckBounds(const AData: TSimpleBaseLibByteArray; AOffset, ANeeded: Integer);
 begin
   if (AOffset < 0) or (AOffset + ANeeded > Length(AData)) then
-    raise EArgumentOutOfRangeException.Create('AOffset');
+    raise EArgumentOutOfRangeSimpleBaseLibException.Create('AOffset');
 end;
 
 // ============================================================================

--- a/SimpleBaseLib/src/Misc/SbpBitOperations.pas
+++ b/SimpleBaseLib/src/Misc/SbpBitOperations.pas
@@ -121,7 +121,7 @@ type
 
 implementation
 
-{ TBitUtilities }
+{ TBitOperations }
 
 class function TBitOperations.ReverseBytesInt32(AValue: Int32): Int32;
 {$IFNDEF FPC}

--- a/SimpleBaseLib/src/Misc/SbpBits.pas
+++ b/SimpleBaseLib/src/Misc/SbpBits.pas
@@ -23,7 +23,8 @@ type
     /// <summary>
     /// Converts a variable length byte array to a 64-bit unsigned integer.
     /// </summary>
-    class function PartialBigEndianBytesToUInt64(const ABytes: TSimpleBaseLibByteArray): UInt64; static;
+    class function PartialBigEndianBytesToUInt64(const ABytes: TSimpleBaseLibByteArray;
+      AOffset, ACount: Int32): UInt64; static;
 
     /// <summary>
     /// Count the number of consecutive zero bytes at the beginning of the given buffer.
@@ -35,19 +36,20 @@ implementation
 
 { TBits }
 
-class function TBits.PartialBigEndianBytesToUInt64(const ABytes: TSimpleBaseLibByteArray): UInt64;
+class function TBits.PartialBigEndianBytesToUInt64(const ABytes: TSimpleBaseLibByteArray;
+  AOffset, ACount: Int32): UInt64;
 var
   LI: Int32;
 begin
-  if System.Length(ABytes) > System.SizeOf(UInt64) then
+  if ACount > System.SizeOf(UInt64) then
   begin
-    raise EArgumentOutOfRangeSimpleBaseLibException.Create('ABytes too long to convert to UInt64');
+    raise EArgumentOutOfRangeSimpleBaseLibException.Create('ACount too large to convert to UInt64');
   end;
 
   Result := 0;
-  for LI := 0 to System.Length(ABytes) - 1 do
+  for LI := 0 to ACount - 1 do
   begin
-    Result := (Result shl 8) or ABytes[LI];
+    Result := (Result shl 8) or ABytes[AOffset + LI];
   end;
 end;
 

--- a/SimpleBaseLib/src/Utilities/SbpStreamUtilities.pas
+++ b/SimpleBaseLib/src/Utilities/SbpStreamUtilities.pas
@@ -119,7 +119,8 @@ begin
 
     SetString(LText, PChar(@LBuffer[0]), LCharsRead);
     LResult := ADecodeBufferFunc(LText);
-    AOutput.Write(LResult[0], System.Length(LResult));
+    if System.Length(LResult) > 0 then
+      AOutput.Write(LResult[0], System.Length(LResult));
   end;
 end;
 


### PR DESCRIPTION
Comprehensive refactoring of all base encoding implementations (Base2, Base8, Base16, Base32, Base45, Base64, Base85, MoneroBase58, DividingCoder, Multibase).

- Made Base64 TryEncode/TryDecode allocation-free with two-layer architecture
- Added static Internal safe-count methods to Base64, matching other bases
- Replaced shr on signed types with TBitOperations.Asr32/Asr64 for cross-platform correctness
- Abstracted reverse lookup access into shared TCodingAlphabet.TryLookup
- Unified decode success path to System.Copy trim pattern across all bases
- Added upfront buffer validation and empty-input guards to all Try* methods
- Deduplicated TBits.PartialBigEndianBytesToUInt64 (MoneroBase58 now uses it)
- Removed redundant Base16Alphabet.MapCounterparts and Multibase helper
- Standardized error messages, exception types, and System-qualified calls
- Various minor fixes: comment typos, bounds guards, empty-result guards