### PR TITLE
extract exception hierarchy into SbpSimpleBaseLibExceptions unit

### DIFF
--- a/SimpleBaseLib.Tests/Delphi.Tests/SimpleBaseLib.Tests.Mobile.dpr
+++ b/SimpleBaseLib.Tests/Delphi.Tests/SimpleBaseLib.Tests.Mobile.dpr
@@ -13,6 +13,7 @@ uses
   SbpBitOperations in '..\..\SimpleBaseLib\src\Misc\SbpBitOperations.pas',
   SbpBinaryPrimitives in '..\..\SimpleBaseLib\src\Misc\SbpBinaryPrimitives.pas',
   SbpSimpleBaseLibTypes in '..\..\SimpleBaseLib\src\Misc\SbpSimpleBaseLibTypes.pas',
+  SbpSimpleBaseLibExceptions in '..\..\SimpleBaseLib\src\Misc\SbpSimpleBaseLibExceptions.pas',
   SbpBits in '..\..\SimpleBaseLib\src\Misc\SbpBits.pas',
   SbpCharUtilities in '..\..\SimpleBaseLib\src\Utilities\SbpCharUtilities.pas',
   SbpStreamUtilities in '..\..\SimpleBaseLib\src\Utilities\SbpStreamUtilities.pas',

--- a/SimpleBaseLib.Tests/Delphi.Tests/SimpleBaseLib.Tests.Mobile.dproj
+++ b/SimpleBaseLib.Tests/Delphi.Tests/SimpleBaseLib.Tests.Mobile.dproj
@@ -353,6 +353,7 @@
         <DCCReference Include="..\..\SimpleBaseLib\src\Misc\SbpBitOperations.pas"/>
         <DCCReference Include="..\..\SimpleBaseLib\src\Misc\SbpBinaryPrimitives.pas"/>
         <DCCReference Include="..\..\SimpleBaseLib\src\Misc\SbpSimpleBaseLibTypes.pas"/>
+        <DCCReference Include="..\..\SimpleBaseLib\src\Misc\SbpSimpleBaseLibExceptions.pas"/>
         <DCCReference Include="..\..\SimpleBaseLib\src\Misc\SbpBits.pas"/>
         <DCCReference Include="..\..\SimpleBaseLib\src\Utilities\SbpCharUtilities.pas"/>
         <DCCReference Include="..\..\SimpleBaseLib\src\Utilities\SbpStreamUtilities.pas"/>

--- a/SimpleBaseLib.Tests/Delphi.Tests/SimpleBaseLib.Tests.dpr
+++ b/SimpleBaseLib.Tests/Delphi.Tests/SimpleBaseLib.Tests.dpr
@@ -30,6 +30,7 @@ uses
   SbpBitOperations in '..\..\SimpleBaseLib\src\Misc\SbpBitOperations.pas',
   SbpBinaryPrimitives in '..\..\SimpleBaseLib\src\Misc\SbpBinaryPrimitives.pas',
   SbpSimpleBaseLibTypes in '..\..\SimpleBaseLib\src\Misc\SbpSimpleBaseLibTypes.pas',
+  SbpSimpleBaseLibExceptions in '..\..\SimpleBaseLib\src\Misc\SbpSimpleBaseLibExceptions.pas',
   SbpBits in '..\..\SimpleBaseLib\src\Misc\SbpBits.pas',
   SbpCharUtilities in '..\..\SimpleBaseLib\src\Utilities\SbpCharUtilities.pas',
   SbpStreamUtilities in '..\..\SimpleBaseLib\src\Utilities\SbpStreamUtilities.pas',

--- a/SimpleBaseLib.Tests/src/Base16/Base16Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base16/Base16Tests.pas
@@ -18,6 +18,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpIBase16,
   SbpBase16,
   SbpBase16Alphabet,

--- a/SimpleBaseLib.Tests/src/Base2/Base2Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base2/Base2Tests.pas
@@ -18,6 +18,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpBase2,
   SimpleBaseLibTestBase;
 

--- a/SimpleBaseLib.Tests/src/Base32/Base32Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base32/Base32Tests.pas
@@ -18,6 +18,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpIBase32,
   SbpBase32,
   SbpBase32Alphabet,

--- a/SimpleBaseLib.Tests/src/Base45/Base45Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base45/Base45Tests.pas
@@ -18,6 +18,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpBase45,
   SimpleBaseLibTestBase;
 

--- a/SimpleBaseLib.Tests/src/Base58/Base58Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base58/Base58Tests.pas
@@ -17,6 +17,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpICodingAlphabet,
   SbpBase58Alphabet,
   SbpBase58,

--- a/SimpleBaseLib.Tests/src/Base64/Base64Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base64/Base64Tests.pas
@@ -18,6 +18,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpIBase64,
   SbpBase64,
   SimpleBaseLibTestBase;

--- a/SimpleBaseLib.Tests/src/Base8/Base8Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base8/Base8Tests.pas
@@ -18,6 +18,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpBase8,
   SimpleBaseLibTestBase;
 

--- a/SimpleBaseLib.Tests/src/Base85/Base85Tests.pas
+++ b/SimpleBaseLib.Tests/src/Base85/Base85Tests.pas
@@ -18,6 +18,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpBase85,
   SimpleBaseLibTestBase;
 

--- a/SimpleBaseLib.Tests/src/Misc/CodingAlphabetTests.pas
+++ b/SimpleBaseLib.Tests/src/Misc/CodingAlphabetTests.pas
@@ -18,6 +18,7 @@ uses
 {$ENDIF FPC}
   SbpCodingAlphabet,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SimpleBaseLibTestBase;
 
 type

--- a/SimpleBaseLib.Tests/src/Multibase/MultibaseTests.pas
+++ b/SimpleBaseLib.Tests/src/Multibase/MultibaseTests.pas
@@ -17,6 +17,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpMultibase,
   SbpMultibaseEncoding,
   SimpleBaseLibTestBase;

--- a/SimpleBaseLib/src/Alphabets/SbpAliasedBase32Alphabet.pas
+++ b/SimpleBaseLib/src/Alphabets/SbpAliasedBase32Alphabet.pas
@@ -5,7 +5,7 @@ unit SbpAliasedBase32Alphabet;
 interface
 
 uses
-  SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpCharMap,
   SbpPaddingPosition,
   SbpCharUtilities,

--- a/SimpleBaseLib/src/Alphabets/SbpCodingAlphabet.pas
+++ b/SimpleBaseLib/src/Alphabets/SbpCodingAlphabet.pas
@@ -7,6 +7,7 @@ interface
 uses
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpICodingAlphabet,
   SbpCharUtilities;
 

--- a/SimpleBaseLib/src/Bases/SbpBase16.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase16.pas
@@ -8,6 +8,7 @@ uses
   SysUtils,
   Classes,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpICodingAlphabet,
   SbpIBase16,
   SbpIBaseStreamCoder,

--- a/SimpleBaseLib/src/Bases/SbpBase2.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase2.pas
@@ -8,6 +8,7 @@ uses
   Classes,
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpIBase2,
   SbpINonAllocatingBaseCoder,
   SbpIBaseStreamCoder,

--- a/SimpleBaseLib/src/Bases/SbpBase32.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase32.pas
@@ -8,6 +8,7 @@ uses
   Classes,
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpIBase32,
   SbpIBaseStreamCoder,
   SbpINonAllocatingBaseCoder,

--- a/SimpleBaseLib/src/Bases/SbpBase45.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase45.pas
@@ -8,6 +8,7 @@ uses
   Classes,
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpSimpleBaseLibConstants,
   SbpICodingAlphabet,
   SbpINonAllocatingBaseCoder,

--- a/SimpleBaseLib/src/Bases/SbpBase64.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase64.pas
@@ -8,6 +8,7 @@ uses
   Classes,
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpSimpleBaseLibConstants,
   SbpIBase64,
   SbpIBase64Alphabet,

--- a/SimpleBaseLib/src/Bases/SbpBase8.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase8.pas
@@ -8,6 +8,7 @@ uses
   Classes,
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpIBase8,
   SbpINonAllocatingBaseCoder,
   SbpIBaseStreamCoder,

--- a/SimpleBaseLib/src/Bases/SbpBase85.pas
+++ b/SimpleBaseLib/src/Bases/SbpBase85.pas
@@ -8,6 +8,7 @@ uses
   Classes,
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpSimpleBaseLibConstants,
   SbpIBase85,
   SbpIBase85Alphabet,

--- a/SimpleBaseLib/src/Bases/SbpMoneroBase58.pas
+++ b/SimpleBaseLib/src/Bases/SbpMoneroBase58.pas
@@ -7,6 +7,7 @@ interface
 uses
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpSimpleBaseLibConstants,
   SbpICodingAlphabet,
   SbpCodingAlphabet,

--- a/SimpleBaseLib/src/Bases/SbpMultibase.pas
+++ b/SimpleBaseLib/src/Bases/SbpMultibase.pas
@@ -7,6 +7,7 @@ interface
 uses
   SysUtils,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpMultibaseEncoding,
   SbpBase2,
   SbpBase8,

--- a/SimpleBaseLib/src/Coders/SbpDividingCoder.pas
+++ b/SimpleBaseLib/src/Coders/SbpDividingCoder.pas
@@ -8,6 +8,7 @@ uses
   SysUtils,
   Math,
   SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions,
   SbpSimpleBaseLibConstants,
   SbpArrayUtilities,
   SbpICodingAlphabet,

--- a/SimpleBaseLib/src/Misc/SbpBits.pas
+++ b/SimpleBaseLib/src/Misc/SbpBits.pas
@@ -5,7 +5,8 @@ unit SbpBits;
 interface
 
 uses
-  SbpSimpleBaseLibTypes;
+  SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions;
 
 resourcestring
   SErrCountTooLarge = 'ACount too large to convert to UInt64';

--- a/SimpleBaseLib/src/Misc/SbpSimpleBaseLibExceptions.pas
+++ b/SimpleBaseLib/src/Misc/SbpSimpleBaseLibExceptions.pas
@@ -1,0 +1,31 @@
+unit SbpSimpleBaseLibExceptions;
+
+{$I ..\Include\SimpleBaseLib.inc}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  ESimpleBaseLibException = class(Exception);
+  EInvalidCastSimpleBaseLibException = class(EInvalidCast);
+  EArithmeticSimpleBaseLibException = class(ESimpleBaseLibException);
+  EInvalidOperationSimpleBaseLibException = class(ESimpleBaseLibException);
+  EInvalidParameterSimpleBaseLibException = class(ESimpleBaseLibException);
+  EIndexOutOfRangeSimpleBaseLibException = class(ESimpleBaseLibException);
+  EArgumentSimpleBaseLibException = class(ESimpleBaseLibException);
+  EInvalidArgumentSimpleBaseLibException = class(ESimpleBaseLibException);
+  EArgumentNilSimpleBaseLibException = class(ESimpleBaseLibException);
+  EArgumentOutOfRangeSimpleBaseLibException = class(ESimpleBaseLibException);
+  ENullReferenceSimpleBaseLibException = class(ESimpleBaseLibException);
+  EUnsupportedTypeSimpleBaseLibException = class(ESimpleBaseLibException);
+  EIOSimpleBaseLibException = class(ESimpleBaseLibException);
+  EFormatSimpleBaseLibException = class(ESimpleBaseLibException);
+  ENotImplementedSimpleBaseLibException = class(ESimpleBaseLibException);
+  ENotSupportedSimpleBaseLibException = class(ESimpleBaseLibException);
+  EEndOfStreamSimpleBaseLibException = class(EIOSimpleBaseLibException);
+
+implementation
+
+end.

--- a/SimpleBaseLib/src/Misc/SbpSimpleBaseLibTypes.pas
+++ b/SimpleBaseLib/src/Misc/SbpSimpleBaseLibTypes.pas
@@ -40,24 +40,6 @@ type
 
   TSimpleBaseLibMethodPredicate<T> = function(Arg1: T): Boolean of object;
 
-  ESimpleBaseLibException = class(Exception);
-  EInvalidCastSimpleBaseLibException = class(EInvalidCast);
-  EArithmeticSimpleBaseLibException = class(ESimpleBaseLibException);
-  EInvalidOperationSimpleBaseLibException = class(ESimpleBaseLibException);
-  EInvalidParameterSimpleBaseLibException = class(ESimpleBaseLibException);
-  EIndexOutOfRangeSimpleBaseLibException = class(ESimpleBaseLibException);
-  EArgumentSimpleBaseLibException = class(ESimpleBaseLibException);
-  EInvalidArgumentSimpleBaseLibException = class(ESimpleBaseLibException);
-  EArgumentNilSimpleBaseLibException = class(ESimpleBaseLibException);
-  EArgumentOutOfRangeSimpleBaseLibException = class(ESimpleBaseLibException);
-  ENullReferenceSimpleBaseLibException = class(ESimpleBaseLibException);
-  EUnsupportedTypeSimpleBaseLibException = class(ESimpleBaseLibException);
-  EIOSimpleBaseLibException = class(ESimpleBaseLibException);
-  EFormatSimpleBaseLibException = class(ESimpleBaseLibException);
-  ENotImplementedSimpleBaseLibException = class(ESimpleBaseLibException);
-  ENotSupportedSimpleBaseLibException = class(ESimpleBaseLibException);
-  EEndOfStreamSimpleBaseLibException = class(EIOSimpleBaseLibException);
-
   /// <summary>
   /// Represents a dynamic array of Byte.
   /// </summary>

--- a/SimpleBaseLib/src/Packages/Delphi/SimpleBaseLib4PascalPackage.dpk
+++ b/SimpleBaseLib/src/Packages/Delphi/SimpleBaseLib4PascalPackage.dpk
@@ -37,6 +37,7 @@ contains
   SbpBitOperations in '..\..\Misc\SbpBitOperations.pas',
   SbpBinaryPrimitives in '..\..\Misc\SbpBinaryPrimitives.pas',
   SbpSimpleBaseLibTypes in '..\..\Misc\SbpSimpleBaseLibTypes.pas',
+  SbpSimpleBaseLibExceptions in '..\..\Misc\SbpSimpleBaseLibExceptions.pas',
   SbpBits in '..\..\Misc\SbpBits.pas',
   SbpCharUtilities in '..\..\Utilities\SbpCharUtilities.pas',
   SbpStreamUtilities in '..\..\Utilities\SbpStreamUtilities.pas',

--- a/SimpleBaseLib/src/Packages/FPC/SimpleBaseLib4PascalPackage.lpk
+++ b/SimpleBaseLib/src/Packages/FPC/SimpleBaseLib4PascalPackage.lpk
@@ -28,7 +28,7 @@
     <Description Value="SimpleBaseLib4Pascal as the name implies is a simple to use Base Encoding Package for Delphi/FreePascal Compilers that provides at the moment support for encoding and decoding various bases such as Base16, Base32 (various variants), Base58 (various variants), Base64 (various variants) and Base85 (various variants)."/>
     <License Value="MIT License"/>
     <Version Major="2" Minor="8"/>
-    <Files Count="66">
+    <Files Count="67">
       <Item1>
         <Filename Value="..\..\Coders\SbpDividingCoder.pas"/>
         <UnitName Value="SbpDividingCoder"/>
@@ -293,6 +293,10 @@
         <Filename Value="..\..\Include\SimpleBaseLibFPC.inc"/>
         <Type Value="Include"/>
       </Item66>
+      <Item67>
+        <Filename Value="..\..\Misc\SbpSimpleBaseLibExceptions.pas"/>
+        <UnitName Value="SbpSimpleBaseLibExceptions"/>
+      </Item67>
     </Files>
     <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="1">

--- a/SimpleBaseLib/src/Packages/FPC/SimpleBaseLib4PascalPackage.pas
+++ b/SimpleBaseLib/src/Packages/FPC/SimpleBaseLib4PascalPackage.pas
@@ -15,15 +15,15 @@ uses
   SbpSimpleBaseLibConstants, SbpBase85Alphabet, SbpIBase85Alphabet, SbpBase58, 
   SbpINumericBaseCoder, SbpBase32Alphabet, SbpINonAllocatingBaseCoder, 
   SbpIBaseStreamCoder, SbpIBaseCoder, SbpAliasedBase32Alphabet, 
-  SbpIAliasedBase32Alphabet, SbpIBase32Alphabet, 
-  SbpCharMap, SbpPaddingPosition, SbpCodingAlphabet, SbpBase45Alphabet, 
+  SbpIAliasedBase32Alphabet, SbpIBase32Alphabet, SbpCharMap, 
+  SbpPaddingPosition, SbpCodingAlphabet, SbpBase45Alphabet, 
   SbpIBase45Alphabet, SbpIDividingCoder, SbpBase62Alphabet, SbpBase58Alphabet, 
   SbpBase36Alphabet, SbpBase10Alphabet, SbpMoneroBase58, SbpBase62, SbpBase36, 
   SbpBase10, SbpBase16Alphabet, SbpIBase58, SbpIBase58Alphabet, 
   SbpIBase62Alphabet, SbpIBase36Alphabet, SbpIBase10Alphabet, SbpIBase62, 
   SbpIBase36, SbpIBase10, SbpSimpleBaseLibTypes, SbpICodingAlphabet, 
   SbpIBase16Alphabet, SbpArrayUtilities, SbpCharUtilities, SbpBits, 
-  SbpBinaryPrimitives, SbpBitOperations;
+  SbpBinaryPrimitives, SbpBitOperations, SbpSimpleBaseLibExceptions;
 
 implementation
 

--- a/SimpleBaseLib/src/Utilities/SbpStreamUtilities.pas
+++ b/SimpleBaseLib/src/Utilities/SbpStreamUtilities.pas
@@ -7,7 +7,8 @@ interface
 uses
   Classes,
   SysUtils,
-  SbpSimpleBaseLibTypes;
+  SbpSimpleBaseLibTypes,
+  SbpSimpleBaseLibExceptions;
 
 resourcestring
   SErrBlockSizeMustBePositive = 'Block size must be positive';


### PR DESCRIPTION
Move every exception class out of SbpSimpleBaseLibTypes into a dedicated SbpSimpleBaseLibExceptions unit (in Misc) so the hierarchy has a clear home and depends only on SysUtils. SbpSimpleBaseLibTypes now holds only the procedure/function pointer types and array aliases.

BREAKING: exception types are no longer visible through SbpSimpleBaseLibTypes; units that raise or handle them must use SbpSimpleBaseLibExceptions.